### PR TITLE
Backport journalList.csv into abbrv repository

### DIFF
--- a/journals/journal_abbreviations_acs.csv
+++ b/journals/journal_abbreviations_acs.csv
@@ -1348,11 +1348,11 @@ Oriental Journal of Chemistry;Orient. J. Chem.
 Oxidation Communications;Oxid. Commun.
 Oxidation of Metals;Oxid. Met.
 Ozone: Science & Engineering;Ozone: Sci. Eng.
-PLoS Biology;PLoS Biol.
-PLoS Computational Biology;PLoS Comput. Biol.
-PLoS Genetics;PLoS Genet.
-PLoS One;PLoS One
-PLoS Pathogens;PLoS Pathog.
+PLOS Biology;PLOS Biol.
+PLOS Computational Biology;PLOS Comput. Biol.
+PLOS Genetics;PLOS Genet.
+PLOS One;PLOS One
+PLOS Pathogens;PLoS Pathog.
 PMSE Preprints;PMSE Prepr.
 Particulate Science and Technology;Part. Sci. Technol.
 Peptides (New York, NY, United States);Peptides (N. Y., NY, U. S.)

--- a/journals/journal_abbreviations_acs.csv
+++ b/journals/journal_abbreviations_acs.csv
@@ -174,7 +174,7 @@ Biochemical Society Transactions;Biochem. Soc. Trans.
 Biochemical Systematics and Ecology;Biochem. Syst. Ecol.
 Biochemical and Biophysical Research Communications;Biochem. Biophys. Res. Commun.
 Biochemistry;Biochemistry
-Biochemistry (Moscow);Biochemistry (Moscow)
+Biochemistry (Moscow);Biochemistry (Mosc.)
 Biochemistry and Cell Biology;Biochem. Cell Biol.
 Biochemistry and Molecular Biology Education;Biochem. Mol. Biol. Educ.
 Biochimica et Biophysica Acta, Bioenergetics;Biochim. Biophys. Acta, Bioenerg.
@@ -296,7 +296,7 @@ Cellular Immunology;Cell. Immunol.
 Cellular Microbiology;Cell. Microbiol.
 Cellular Physiology and Biochemistry;Cell. Physiol. Biochem.
 Cellular Polymers;Cell. Polym.
-Cellular Reprogramming;Cell. Reprogram.
+Cellular Reprogramming;Cell. Reprogramming
 Cellular and Molecular Life Sciences;Cell. Mol. Life Sci.
 Cellulose Chemistry and Technology;Cellul. Chem. Technol.
 Cement & Concrete Composites;Cem. Concr. Compos.
@@ -434,8 +434,8 @@ Current Cancer Drug Targets;Curr. Cancer Drug Targets
 Current Catalysis;Curr. Catal.
 Current Chemical Biology;Curr. Chem. Biol.
 Current Computer-Aided Drug Design;Curr. Comput.-Aided Drug Des.
-Current Drug Delivery;Curr. Drug Delivery
-Current Drug Discovery Technologies;Curr. Drug Discovery Technol.
+Current Drug Delivery;Curr. Drug Deliv.
+Current Drug Discovery Technologies;Curr. Drug Discov. Technol.
 Current Drug Metabolism;Curr. Drug Metab.
 Current Drug Targets;Curr. Drug Targets
 Current Enzyme Inhibition;Curr. Enzyme Inhib.
@@ -554,8 +554,8 @@ Environmental Toxicology and Pharmacology;Environ. Toxicol. Pharmacol.
 Environmental and Molecular Mutagenesis;Environ. Mol. Mutagen.
 Enzyme and Microbial Technology;Enzyme Microb. Technol.
 Epigenomics;Epigenomics
-Eukaryotic Cell;Eukaryotic Cell
-European Cytokine Network;Eur. Cytokine Network
+Eukaryotic Cell;Eukaryot. Cell
+European Cytokine Network;Eur. Cytokine Netw.
 European Food Research and Technology;Eur. Food Res. Technol.
 European Journal of Cell Biology;Eur. J. Cell Biol.
 European Journal of Chemistry;Eur. J. Chem.
@@ -648,7 +648,7 @@ Gaofenzi Cailiao Kexue Yu Gongcheng;Gaofenzi Cailiao Kexue Yu Gongcheng
 Gaofenzi Xuebao;Gaofenzi Xuebao
 Gaoxiao Huaxue Gongcheng Xuebao;Gaoxiao Huaxue Gongcheng Xuebao
 Gene;Gene
-Gene Expression Patterns;Gene Expression Patterns
+Gene Expression Patterns;Gene Expr. Patterns
 Gene Therapy;Gene Ther.
 General and Comparative Endocrinology;Gen. Comp. Endocrinol.
 Genes;Genes
@@ -736,8 +736,8 @@ Indian Journal of Physics;Indian J. Phys.
 Industrial & Engineering Chemistry Research;Ind. Eng. Chem. Res.
 Infection and Immunity;Infect. Immun.
 Infectious Disorders: Drug Targets;Infect. Disord.: Drug Targets
-Inflammation & Allergy: Drug Targets;Inflammation Allergy: Drug Targets
-Inflammation Research;Inflammation Res.
+Inflammation & Allergy: Drug Targets;Inflamm. Allergy: Drug Targets
+Inflammation Research;Inflamm. Res.
 Inhalation Toxicology;Inhalation Toxicol.
 Innate Immunity;Innate Immun.
 Inorganic Chemistry;Inorg. Chem.
@@ -905,8 +905,8 @@ Journal of Environmental Engineering (Reston, VA, United States);J. Environ. Eng
 Journal of Environmental Quality;J. Environ. Qual.
 Journal of Environmental Radioactivity;J. Environ. Radioact.
 Journal of Environmental Science & Engineering (Nagpur, India);J. Environ. Sci. Eng. (Nagpur, India)
-Journal of Environmental Science and Health, Part A: Toxic/Hazardous Substances & Environmental Engineering;J. Environ. Sci. Health, Part A: Toxic/Hazard. Subst. Environ. Eng.
-Journal of Environmental Science and Health, Part B: Pesticides, Food Contaminants, and Agricultural Wastes;J. Environ. Sci. Health, Part B
+Journal of Environmental Science and Health, Part A: Toxic/Hazardous Substances & Environmental Engineering;J. Environ. Sci. Health A: Toxic/Hazard. Subst. Environ. Eng.
+Journal of Environmental Science and Health, Part B: Pesticides, Food Contaminants, and Agricultural Wastes;J. Environ. Sci. Health B
 Journal of Enzyme Inhibition and Medicinal Chemistry;J. Enzyme Inhib. Med. Chem.
 Journal of Experimental Botany;J. Exp. Bot.
 Journal of Experimental Medicine;J. Exp. Med.
@@ -967,7 +967,7 @@ Journal of Molecular Catalysis A: Chemical;J. Mol. Catal. A: Chem.
 Journal of Molecular Catalysis B: Enzymatic;J. Mol. Catal. B: Enzym.
 Journal of Molecular Endocrinology;J. Mol. Endocrinol.
 Journal of Molecular Evolution;J. Mol. Evol.
-Journal of Molecular Graphics & Modelling;J. Mol. Graphics Modell.
+Journal of Molecular Graphics & Modelling;J. Mol. Graphics Model.
 Journal of Molecular Liquids;J. Mol. Liq.
 Journal of Molecular Microbiology and Biotechnology;J. Mol. Microbiol. Biotechnol.
 Journal of Molecular Neuroscience;J. Mol. Neurosci.
@@ -1245,9 +1245,9 @@ Molecules and Cells;Mol. Cells
 Monatshefte fuer Chemie;Monatsh. Chem.
 Mucosal Immunology;Mucosal Immunol.
 Mutagenesis;Mutagenesis
-Mutation Research, Fundamental and Molecular Mechanisms of Mutagenesis;Mutat. Res., Fundam. Mol. Mech. Mutagen.
-Mutation Research, Genetic Toxicology and Environmental Mutagenesis;Mutat. Res., Genet. Toxicol. Environ. Mutagen.
-Mutation Research, Reviews in Mutation Research;Mutat. Res., Rev. Mutat. Res.
+Mutation Research, Fundamental and Molecular Mechanisms of Mutagenesis;Mutat. Res. Fundam. Mol. Mech. Mutagen.
+Mutation Research, Genetic Toxicology and Environmental Mutagenesis;Mutat. Res. Genet. Toxicol. Environ. Mutagen.
+Mutation Research, Reviews in Mutation Research;Mutat. Res. Rev. Mutat. Res.
 Nano;Nano
 Nano Energy;Nano Energy
 Nano Express;Nano Express
@@ -1357,7 +1357,7 @@ PMSE Preprints;PMSE Prepr.
 Particulate Science and Technology;Part. Sci. Technol.
 Peptides (New York, NY, United States);Peptides (N. Y., NY, U. S.)
 Personalized Medicine;Pers. Med.
-Pest Management Science;Pest Manage. Sci.
+Pest Management Science;Pest Manag. Sci.
 Pesticide Biochemistry and Physiology;Pestic. Biochem. Physiol.
 Petroleum Chemistry;Pet. Chem.
 Petroleum Science and Technology;Pet. Sci. Technol.

--- a/journals/journal_abbreviations_ams.csv
+++ b/journals/journal_abbreviations_ams.csv
@@ -109,9 +109,9 @@ Advanced Studies in Pure Mathematics;Adv. Stud. Pure Math.
 Advanced Texts in Econometrics;Adv. Texts Econometrics
 Advances in Theoretical and Mathematical Physics;Adv. Theor. Math. Phys.
 Advanced Topics in Mathematics;Adv. Top. Math.
-Advances in Applied Mathematics;Adv. in Appl. Math.
-Advances in Applied Probability;Adv. in Appl. Probab.
-Advances in Mathematics (China);Adv. in Math. (China)
+Advances in Applied Mathematics;Adv. Appl. Math.
+Advances in Applied Probability;Adv. Appl. Probab.
+Advances in Mathematics (China);Adv. Math. (China)
 Aequationes Mathematicae;Aequationes Math.
 Aerospace Science and Technology;Aerosp. Sci. Technol.
 Afrika Matematika;Afrika Mat. (3)
@@ -181,11 +181,11 @@ Annales de l'Institut Henri Poincaré;Ann. Inst. H. Poincaré Anal. Non Linéair
 Annales de l'Institut Henri Poincaré;Ann. Inst. H. Poincaré Phys. Théor.
 Annales de l'Institut Henri Poincaré;Ann. Inst. H. Poincaré Probab. Statist.
 Annals of the Institute of Statistical Mathematics;Ann. Inst. Statist. Math.
-Annals of the International Society of Dynamic Games;Ann. Internat. Soc. Dynam. Games
+Annals of the International Society of Dynamic Games;Ann. Int. Soc. Dynam. Games
 Annals of the Israel Physical Society;Ann. Israel Phys. Soc.
 Annals of the Japan Association for Philosophy of Science;Ann. Japan Assoc. Philos. Sci.
 Annali di Matematica Pura ed Applicata;Ann. Mat. Pura Appl. (4)
-Annals of Mathematics and Artificial Intelligence;Ann. Math. Artificial Intelligence
+Annals of Mathematics and Artif. Intell.;Ann. Math. Artif. Intell.
 Annales Mathématiques Blaise Pascal;Ann. Math. Blaise Pascal
 Annales Mathematicae Silesianae;Ann. Math. Sil.
 Annals of the New York Academy of Sciences;Ann. New York Acad. Sci.
@@ -238,8 +238,8 @@ Applied Mathematics and Engineering Science Texts;Appl. Math. Engrg. Sci. Texts
 Applied Mathematics;Appl. Math. J. Chinese Univ. Ser. B
 Applied Mathematics Letters;Appl. Math. Lett.
 Applied Mathematics and Mathematical Computation;Appl. Math. Math. Comput.
-Applied Mathematics and Mechanics;Appl. Math. Mech.
 Applied Mathematics and Mechanics;Appl. Math. Mech. (English Ed.)
+Applied Mathematics and Mechanics;Appl. Math. Mech.
 Applied Mathematics and Optimization;Appl. Math. Optim.
 Applied Mathematical Sciences;Appl. Math. Sci.
 Applied and Numerical Harmonic Analysis;Appl. Numer. Harmon. Anal.
@@ -262,7 +262,7 @@ Archives of Computational Methods in Engineering;Arch. Comput. Methods Engrg.
 Polish Academy of Sciences;Arch. Control Sci.
 Archivio della Corrispondenza degli Scienziati Italiani;Arch. Corrisp. Sci. Italiani
 Archive for History of Exact Sciences;Arch. Hist. Exact Sci.
-Archives Internationales d'Histoire des Sciences;Arch. Internat. Hist. Sci.
+Archives Internationales d'Histoire des Sciences;Arch. Int. Hist. Sci.
 Archiv der Mathematik;Arch. Math. (Basel)
 Universitatis Masarykianae Brunensis;Arch. Math. (Brno)
 Archive for Mathematical Logic;Arch. Math. Logic
@@ -275,7 +275,7 @@ Arkhimedes;Arkhimedes
 Ars Combinatoria;Ars Combin.
 Artech House Antenna Library;Artech House Antenna Lib.
 The Artech House Signal Processing Library;Artech House Signal Process. Libr.
-Artificial Intelligence;Artificial Intelligence
+Artif. Intell.;Artif. Intell.
 Asia-Pacific Journal of Operational Research;Asia-Pacific J. Oper. Res.
 The Asian Journal of Mathematics;Asian J. Math.
 Aspekte Komplexer Systeme;Asp. Komplexer Systeme
@@ -475,7 +475,7 @@ Cambridge Monographs on Atomic, Molecular and Chemical Physics;Camb. Monogr. At.
 Cambridge Monographs on Particle Physics, Nuclear Physics and Cosmology;Camb. Monogr. Part. Phys. Nucl. Phys. Cosmol.
 Cambridge Series on Statistical and Probabilistic Mathematics;Camb. Ser. Stat. Probab. Math.
 Cambridge Texts in the History of Philosophy;Camb. Texts Hist. Philos.
-Cambridge International Series on Parallel Computation;Cambridge Internat. Ser. Parallel Comput.
+Cambridge International Series on Parallel Computation;Cambridge Int. Ser. Parallel Comput.
 Cambridge Lecture Notes in Physics;Cambridge Lecture Notes Phys.
 Cambridge Mathematical Library;Cambridge Math. Lib.
 Cambridge Monographs on Applied and Computational Mathematics;Cambridge Monogr. Appl. Comput. Math.
@@ -597,12 +597,12 @@ Complex Systems;Complex Systems
 Complex Variables;Complex Variables Theory Appl.
 Complexity International;Complex. Int.
 Complexity;Complexity
-Complexity International;Complexity Internat.
+Complexity International;Complexity Int.
 Compositio Mathematica;Compositio Math.
 Computers & Fluids;Comput. & Fluids
 Computers & Structures;Comput. & Structures
-Computer Aided Geometric Design;Comput. Aided Geom. Design
-Computers and Artificial Intelligence;Comput. Artificial Intelligence
+Computer Aided Geometric Design;Comput. Aided Geom. Des.
+Computers and Artif. Intell.;Comput. Artif. Intell.
 Computational Complexity;Comput. Complexity
 Computational Geometry;Comput. Geom.
 Computational Imaging and Vision;Comput. Imaging Vision
@@ -614,7 +614,7 @@ Computational Mathematics and Mathematical Physics;Comput. Math. Math. Phys.
 Computational Mathematics and Modeling;Comput. Math. Model.
 Computational & Mathematical Organization Theory;Comput. Math. Organ. Theory
 Computational Mechanics;Comput. Mech.
-Computer Methods in Applied Mechanics and Engineering;Comput. Methods Appl. Mech. Engrg.
+Computer Methods in Applied Mechanics and Engineering;Comput. Methods Appl. Mech. Eng.
 Computer Modeling and Simulation in Engineering;Comput. Model. Simul. Engrg.
 Computers & Operations Research and their Application to Problems of World Concern;Comput. Oper. Res.
 Computational Optimization and Applications;Comput. Optim. Appl.
@@ -719,7 +719,11 @@ Dynamics and Stability of Systems;Dynam. Stability Systems
 Dynamic Systems and Applications;Dynam. Systems Appl.
 ERCOFTAC Series;ERCOFTAC Ser.
 ESAIM;ESAIM Control Optim. Calc. Var.
+European Journal of Applied Mathematics;Eur. J. Appl. Math.
+European Journal of Combinatorics;Eur. J. Combin.
+European Journal of Operational Research;Eur. J. Oper. Res.
 European Series in Applied and Industrial Mathematics;ESAIM Probab. Statist.
+European University Institute. Series D: Economics;Eur. Univ. Inst. Ser. D: Econom.
 ESAIM Proceedings;ESAIM Proc.
 EUT Report-WSK;EUT Report-WSK
 Early Science and Medicine;Early Sci. Med.
@@ -830,7 +834,7 @@ Fractals;Fractals
 Freiburger Studien zur Frühen Neuzeit;Freibg. Stud. Frühen Neuzeit
 Frieling-Erinnerungen;Frieling-Erinnerungen
 Frontiers in Applied Mathematics;Frontiers Appl. Math.
-Frontiers in Artificial Intelligence and Applications;Frontiers Artificial Intelligence Appl.
+Frontiers in Artif. Intell. and Applications;Frontiers Artif. Intell. Appl.
 Frontiers of Economic Research;Frontiers Econom. Res.
 Fujian Shifan Daxue Xuebao;Fujian Shifan Daxue Xuebao Ziran Kexue Ban
 Fukuoka University Science Reports;Fukuoka Univ. Sci. Rep.
@@ -843,7 +847,7 @@ Fundamental Theories of Physics;Fund. Theories Phys.
 Fako de l'Funkcialaj Ekvacioj Japana Matematika Societo;Funkcial. Ekvac.
 Rossíiskaya Akademiya Nauk;Funktsional. Anal. i Prilozhen.
 Fuzzy Sets and Systems;Fuzzy Sets and Systems
-GAKUTO International Series;GAKUTO Internat. Ser. Math. Sci. Appl.
+GAKUTO International Series;GAKUTO Int. Ser. Math. Sci. Appl.
 Mitteilungen der Gesellschaft für Angewandte Mathematik und Mechanik;GAMM Mitt. Ges. Angew. Math. Mech.
 GMD Research Series;GMD Res. Ser.
 GMD-Berichte;GMD-Ber.
@@ -974,7 +978,7 @@ Lithuanian Academy of Sciences;Informatica (Vilnius)
 Information;Information
 Innovations in Applied Mathematics;Innov. Appl. Math.
 Institut des Hautes études Scientifiques;Inst. Hautes études Sci. Publ. Math.
-Institutionen für Internationell Pedagogik;Inst. Internat. Pedagog. Report
+Institutionen für Internationell Pedagogik;Inst. Int. Pedagog. Report
 The Institute of Mathematics and its Applications Conference Series;Inst. Math. Appl. Conf. Ser. New Ser.
 Institute for Nonlinear Science;Inst. Nonlinear Sci.
 "Institutul Politehnic ""Traian Vuia"" Timișoara";Inst. Politehn. Traian Vuia Timișoara Lucrăr. Sem. Mat. Fiz.
@@ -994,47 +998,47 @@ Interdisciplinary Information Sciences;Interdiscip. Inform. Sci.
 Interdisciplinary Mathematics;Interdiscip. Math.
 Interdisciplinary Statistics;Interdiscip. Statist.
 """Interferences"" Series";Interf. Ser.
-International Applied Mechanics;Internat. Appl. Mech.
-International Economic Review;Internat. Econom. Rev.
-International Journal of Adaptive Control and Signal Processing;Internat. J. Adapt. Control Signal Process.
-International Journal of Algebra and Computation;Internat. J. Algebra Comput.
-International Journal of Applied Science and Computations;Internat. J. Appl. Sci. Comput.
-International Journal of Approximate Reasoning;Internat. J. Approx. Reason.
-International Journal of Bifurcation and Chaos in Applied Sciences and Engineering;Internat. J. Bifur. Chaos Appl. Sci. Engrg.
-International Journal of Computational Geometry & Applications;Internat. J. Comput. Geom. Appl.
-International Journal of Control;Internat. J. Control
-International Journal of Engineering Science;Internat. J. Engrg. Sci.
-International Journal of Game Theory;Internat. J. Game Theory
-International Journal of Information and Management Sciences;Internat. J. Inform. Management Sci.
-International Journal of Mathematics;Internat. J. Math.
-International Journal of Mathematical Education in Science and Technology;Internat. J. Math. Ed. Sci. Tech.
-International Journal of Mathematics and Mathematical Sciences;Internat. J. Math. Math. Sci.
-International Journal of Modern Physics A;Internat. J. Modern Phys. A
-International Journal of Modern Physics B;Internat. J. Modern Phys. B
-International Journal of Modern Physics C;Internat. J. Modern Phys. C
-International Journal of Modern Physics;Internat. J. Modern Phys. D
-International Journal of Modern Physics;Internat. J. Modern Phys. E
-International Journal of Non-Linear Mechanics;Internat. J. Non-Linear Mech.
-International Journal for Numerical Methods in Engineering;Internat. J. Numer. Methods Engrg.
-International Journal for Numerical Methods in Fluids;Internat. J. Numer. Methods Fluids
-International Journal of Numerical Methods for Heat & Fluid Flow;Internat. J. Numer. Methods Heat Fluid Flow
-International Journal of Robust and Nonlinear Control;Internat. J. Robust Nonlinear Control
-International Journal of Solids and Structures;Internat. J. Solids Structures
-International Journal of Theoretical Physics;Internat. J. Theoret. Phys.
-International Journal of Uncertainty, Fuzziness and Knowledge-Based Systems;Internat. J. Uncertain. Fuzziness Knowledge-Based Systems
-International Mathematical News;Internat. Math. News
-International Mathematics Research Notices;Internat. Math. Res. Notices
-International Schools for Computer Scientists;Internat. Schools Comput. Sci.
-International Series on Computational Engineering;Internat. Ser. Comput. Engrg.
-International Series in Intelligent Technologies;Internat. Ser. Intell. Tech.
-International Series of Monographs on Chemistry;Internat. Ser. Monogr. Chem.
-International Series of Monographs on Physics;Internat. Ser. Monogr. Phys.
-International Series of Numerical Mathematics;Internat. Ser. Numer. Math.
-International Series in Operations Research & Management Science;Internat. Ser. Oper. Res. Management Sci.
-International Studies in the Philosophy of Science;Internat. Stud. Philos. Sci.
-International Symposia in Economic Theory and Econometrics;Internat. Sympos. Econom. Theory Econometrics
-International Union of Crystallography Crystallographic Symposia;Internat. Union Cryst. Cryst. Sympos.
-International Year-Book of Game Theory and Applications;Internat. Year-Book Game Theory Appl.
+International Applied Mechanics;Int. Appl. Mech.
+International Economic Review;Int. Econom. Rev.
+International Journal of Adaptive Control and Signal Processing;Int. J. Adapt. Control Signal Process.
+International Journal of Algebra and Computation;Int. J. Algebra Comput.
+International Journal of Applied Science and Computations;Int. J. Appl. Sci. Comput.
+International Journal of Approximate Reasoning;Int. J. Approx. Reason.
+International Journal of Bifurcation and Chaos in Applied Sciences and Engineering;Int. J. Bifur. Chaos Appl. Sci. Engrg.
+International Journal of Computational Geometry & Applications;Int. J. Comput. Geom. Appl.
+International Journal of Control;Int. J. Control
+International Journal of Engineering Science;Int. J. Engrg. Sci.
+International Journal of Game Theory;Int. J. Game Theory
+International Journal of Information and Management Sciences;Int. J. Inform. Management Sci.
+International Journal of Mathematics;Int. J. Math.
+International Journal of Mathematical Education in Science and Technology;Int. J. Math. Ed. Sci. Tech.
+International Journal of Mathematics and Mathematical Sciences;Int. J. Math. Math. Sci.
+International Journal of Modern Physics A;Int. J. Modern Phys. A
+International Journal of Modern Physics B;Int. J. Modern Phys. B
+International Journal of Modern Physics C;Int. J. Modern Phys. C
+International Journal of Modern Physics;Int. J. Modern Phys. D
+International Journal of Modern Physics;Int. J. Modern Phys. E
+International Journal of Non-Linear Mechanics;Int. J. Non-Linear Mech.
+International Journal for Numerical Methods in Engineering;Int. J. Numer. Methods Engrg.
+International Journal for Numerical Methods in Fluids;Int. J. Numer. Methods Fluids
+International Journal of Numerical Methods for Heat & Fluid Flow;Int. J. Numer. Methods Heat Fluid Flow
+International Journal of Robust and Nonlinear Control;Int. J. Robust Nonlinear Control
+International Journal of Solids and Structures;Int. J. Solids Structures
+International Journal of Theoretical Physics;Int. J. Theoret. Phys.
+International Journal of Uncertainty, Fuzziness and Knowledge-Based Systems;Int. J. Uncertain. Fuzziness Knowledge-Based Systems
+International Mathematical News;Int. Math. News
+International Mathematics Research Notices;Int. Math. Res. Notices
+International Schools for Computer Scientists;Int. Schools Comput. Sci.
+International Series on Computational Engineering;Int. Ser. Comput. Engrg.
+International Series in Intelligent Technologies;Int. Ser. Intell. Tech.
+International Series of Monographs on Chemistry;Int. Ser. Monogr. Chem.
+International Series of Monographs on Physics;Int. Ser. Monogr. Phys.
+International Series of Numerical Mathematics;Int. Ser. Numer. Math.
+International Series in Operations Research & Management Science;Int. Ser. Oper. Res. Management Sci.
+International Studies in the Philosophy of Science;Int. Stud. Philos. Sci.
+International Symposia in Economic Theory and Econometrics;Int. Sympos. Econom. Theory Econometrics
+International Union of Crystallography Crystallographic Symposia;Int. Union Cryst. Cryst. Sympos.
+International Year-Book of Game Theory and Applications;Int. Year-Book Game Theory Appl.
 Inventiones Mathematicae;Invent. Math.
 Inverse and Ill-posed Problems Series;Inverse Ill-posed Probl. Ser.
 Inverse Problems;Inverse Problems
@@ -1093,7 +1097,7 @@ Journal of Applied Probability;J. Appl. Probab.
 Journal of Applied Statistics;J. Appl. Statist.
 Journal of Applied Statistical Science;J. Appl. Statist. Sci.
 Journal of Approximation Theory;J. Approx. Theory
-Journal of Artificial Intelligence Research;J. Artificial Intelligence Res.
+Journal of Artif. Intell. Research;J. Artif. Intell. Res.
 Journal of the Asahikawa National College of Technology;J. Asahikawa Nat. College Tech.
 Journal of the Assam Science Society;J. Assam Sci. Soc.
 American Astronautical Society;J. Astronaut. Sci.
@@ -1153,7 +1157,7 @@ Journal of Engineering Mathematics;J. Engrg. Math.
 Journal of Experimental and Theoretical Physics;J. Experiment. Theoret. Phys.
 Journal of the Faculty of Engineering;J. Fac. Engrg. Chiba Univ.
 Journal of the Faculty of Engineering;J. Fac. Engrg. Univ. Tokyo Ser. B
-Kyushu Sangyo University;J. Fac. Internat. Stud. Cult. Kyushu Sangyo Univ.
+Kyushu Sangyo University;J. Fac. Int. Stud. Cult. Kyushu Sangyo Univ.
 Journal of the Faculty of Liberal Arts;J. Fac. Liberal Arts Yamaguchi Univ. Natur. Sci.
 Journal of the Faculty of Science and Engineering;J. Fac. Sci. Eng. Kinki Univ.
 Journal of the Faculty of Science;J. Fac. Sci. Shinshu Univ.
@@ -1327,7 +1331,7 @@ JNUL Publications;JNUL Publ.
 Jaakko Hintikka Selected Papers;Jaakko Hintikka Sel. Pap.
 Jahresbericht der Deutschen Mathematiker-Vereinigung;Jahresber. Deutsch. Math.-Verein.
 Japan Journal of Industrial and Applied Mathematics;Japan J. Indust. Appl. Math.
-Japanese Journal of Mathematics;Japan. J. Math. (N.S.)
+Japanese Journal of Mathematics;Jpn. J. Math. (N.S.)
 Japanese Journal of Fuzzy Theory and Systems;Japanese J. Fuzzy Theory Systems
 Joensuun Yliopiston Luonnontieteellisiä Julkaisuja;Joensuun Yliop. Luonnont. Julk.
 Johns Hopkins Studies in the Mathematical Sciences;Johns Hopkins Stud. Math. Sci.
@@ -1343,7 +1347,7 @@ Natsional\cprime naya Akademiya Nauk Ukrainy;Kibernet. Sistem. Anal.
 Akademiya Nauk Ukrainy;Kibernet. i Vychisl. Tekhn.
 Kluwer International Handbooks of Education;Kluwer Int. Handb. Educ.
 The Kluwer International Series on Discrete Event Dynamic Systems;Kluwer Int. Ser. Discrete Event Dyn. Syst.
-The Kluwer International Series in Engineering and Computer Science;Kluwer Internat. Ser. Engrg. Comput. Sci.
+The Kluwer International Series in Engineering and Computer Science;Kluwer Int. Ser. Engrg. Comput. Sci.
 Kluwer Texts in the Mathematical Sciences;Kluwer Texts Math. Sci.
 Kobe Journal of Mathematics;Kobe J. Math.
 Kodai Mathematical Journal;Kodai Math. J.
@@ -1369,7 +1373,7 @@ Lecture Notes in Logic;Lecture Notes Logic
 Lecture Notes in Numerical and Applied Analysis;Lecture Notes Numer. Appl. Anal.
 Lecture Notes Series;Lecture Notes Ser.
 Lecture Notes Series on Computing;Lecture Notes Ser. Comput.
-Lecture Notes in Artificial Intelligence;Lecture Notes in Artificial Intelligence
+Lecture Notes in Artif. Intell.;Lecture Notes in Artif. Intell.
 Lecture Notes in Biomathematics;Lecture Notes in Biomath.
 Lecture Notes in Chemistry;Lecture Notes in Chem.
 Lecture Notes in Computer Science;Lecture Notes in Comput. Sci.
@@ -1415,7 +1419,7 @@ M;M. B. Porter Lectures
 MAA Notes;MAA Notes
 MAA Spectrum;MAA Spectrum
 Modeling, Identification and Control;MIC---Model. Identif. Control
-MIT Press Series in Artificial Intelligence;MIT Press Ser. Artificial Intelligence
+MIT Press Series in Artif. Intell.;MIT Press Ser. Artif. Intell.
 MIT Press Series on Economic Learning and Social Evolution;MIT Press Ser. Econ. Learn. Soc. Evol.
 MIT Press Series in Logic Programming;MIT Press Ser. Logic Program.
 MLQ;MLQ Math. Log. Q.
@@ -1764,7 +1768,7 @@ Philosophical Perspectives;Philos. Perspect.
 The Philosophical Quarterly;Philos. Quart.
 Philosophy of Science;Philos. Sci.
 Philosophical Studies;Philos. Stud.
-Philosophical Transactions of the Royal Society of London;Philos. Trans. Roy. Soc. London Ser. A
+Philosophical Transactions of the Royal Society of London;Philos. Trans. Roy. Soc. London
 Philosophica;Philosophica
 Philosophies;Philosophies
 Physica A;Phys. A
@@ -1809,8 +1813,8 @@ Prace Naukowe Instytutu Cybernetyki Technicznej Politechniki Wrocławskiej;Prace
 Politechnika Wrocławska;Prace Nauk. Inst. Cybernet. Tech. Politech. Wrocław. Ser. Monograf.
 Wrocław;Prace Nauk. Inst. Mat. Politech. Wrocław. Ser. Monograf.
 Prentice Hall Information and System Sciences Series;Prentice Hall Inform. System Sci. Ser.
-Prentice Hall International Series in Computer Science;Prentice Hall Internat. Ser. Comput. Sci.
-Prentice Hall International Series in Industrial and Systems Engineering;Prentice Hall Internat. Ser. Indust. Systems Engrg.
+Prentice Hall International Series in Computer Science;Prentice Hall Int. Ser. Comput. Sci.
+Prentice Hall International Series in Industrial and Systems Engineering;Prentice Hall Int. Ser. Indust. Systems Engrg.
 Prentice Hall Series on Environmental and Intelligent Manufacturing Systems;Prentice Hall Ser. Environ. Intell. Manuf. Syst.
 Preprint;Preprint
 Rossíiskaya Akademiya Nauk;Prikl. Mat. Mekh.
@@ -1847,21 +1851,21 @@ Proceedings of the Edinburgh Mathematical Society;Proc. Edinburgh Math. Soc. (2)
 Proceedings of the Estonian Academy of Sciences;Proc. Est. Acad. Sci. Eng.
 Estonian Academy of Sciences;Proc. Estonian Acad. Sci. Phys. Math.
 Indian Academy of Sciences;Proc. Indian Acad. Sci. Math. Sci.
-Proceedings of the Indian National Science Academy;Proc. Indian Nat. Sci. Acad. Part A
+Proceedings of the Indian National Science Academy;Proc. Indian Nat. Sci. Acad.
 The Proceedings of the Institute of Statistical Mathematics;Proc. Inst. Statist. Math.
-"Proceedings of the International School of Physics ""Enrico Fermi""";Proc. Internat. School Phys. Enrico Fermi
+"Proceedings of the International School of Physics ""Enrico Fermi""";Proc. Int. School Phys. Enrico Fermi
 Japan Academy;Proc. Japan Acad. Ser. A Math. Sci.
 Koninklijke Nederlandse Akademie van Wetenschappen;Proc. Konink. Nederl. Akad. Wetensch.
 Proceedings of the London Mathematical Society;Proc. London Math. Soc. (3)
 Proceedings of the Mathematical and Physical Society of Egypt;Proc. Math. Phys. Soc. Egypt
 Proceedings of the Mathematical Society;Proc. Math. Soc.
-Proceedings of the National Academy of Sciences, India;Proc. Nat. Acad. Sci. India Sect. A
+Proceedings of the National Academy of Sciences, India;Proc. Nat. Acad. Sci. India
 Proceedings of the National Academy of Sciences of the United States of America;Proc. Nat. Acad. Sci. U.S.A.
 Proceedings of the National Academy of Sciences of the United States of America;Proc. Natl. Acad. Sci. USA
 Proceedings of the Pakistan Academy of Sciences;Proc. Pakistan Acad. Sci.
-Proceedings of the Royal Irish Academy;Proc. Roy. Irish Acad. Sect. A
-Proceedings of the Royal Society of Edinburgh;Proc. Roy. Soc. Edinburgh Sect. A
-Proceedings of the Royal Society;Proc. Roy. Soc. London Ser. A
+Proceedings of the Royal Irish Academy;Proc. Roy. Irish Acad.
+Proceedings of the Royal Society of Edinburgh;Proc. Roy. Soc. Edinburgh
+Proceedings of the Royal Society;Proc. Roy. Soc. London
 Proceedings;Proc. SPIE
 Proceedings of the School of Science of Tokai University;Proc. Sch. Sci. Tokai Univ.
 Proceedings of the School of Science of Tokai University;Proc. School Sci. Tokai Univ.
@@ -2233,7 +2237,7 @@ Studii şi Cercetări Matematice;Stud. Cerc. Mat.
 Studii şi Cercetări de Mecanică Aplicată;Stud. Cerc. Mec. Apl.
 Studies in Classification, Data Analysis, and Knowledge Organization;Stud. Classification Data Anal. Knowledge Organ.
 Studies in Computational Mathematics;Stud. Comput. Math.
-Studies in Computer Science and Artificial Intelligence;Stud. Comput. Sci. Artificial Intelligence
+Studies in Computer Science and Artif. Intell.;Stud. Comput. Sci. Artif. Intell.
 Studies in Dynamical Economic Science;Stud. Dynam. Econom. Sci.
 Studies in Economic Theory;Stud. Econom. Theory
 Studies in Empirical Economics;Stud. Empir. Econom.
@@ -2459,7 +2463,7 @@ Vieweg Textbook Mathematics;Vieweg Textbook Math.
 Vijnana Parishad Anusandhan Patrika;Vijnana Parishad Anusandhan Patrika
 The Vikram Mathematical Journal;Vikram Math. J.
 The Virtual Laboratory;Virtual Lab.
-Vishwa International Journal of Graph Theory;Vishwa Internat. J. Graph Theory
+Vishwa International Journal of Graph Theory;Vishwa Int. J. Graph Theory
 Vistas in Astronomy;Vistas Astronom.
 Vita Mathematica;Vita Math.
 Vivarium;Vivarium

--- a/journals/journal_abbreviations_general.csv
+++ b/journals/journal_abbreviations_general.csv
@@ -1,14 +1,62 @@
+3D Printing and Additive Manufacturing;3D Print. Addit. Manuf.;;
+ABB Review;ABB Rev.;;
+ACH - Models in Chemistry;ACH - Models Chem.
+ACI Materials Journal;ACI Mater. J.
+ACI Structural Journal;ACI Struct. J.;;
+ACM Computing Surveys;ACM Comput. Surv.;;
+ACM Journal of Data and Information Quality;ACM J. Data Inf. Qual.;;
+ACM Journal on Computing and Cultural Heritage;ACM J. Comput. Cult. Heritage;;
+ACM Journal on Emerging Technologies in Computing;ACM J. Emerging Technol. Comput.;;
+ACM Transactions on Accessible Computing;ACM Trans. Accessible Comput.;;
+ACM Transactions on Applied Perception;ACM Trans. Appl. Percept.;;
+ACM Transactions on Architecture and Code Optimization;ACM Trans. Archit. Code Optim.;;
+ACM Transactions on Asian Language Information Processing;ACM Trans. Asian Lang. Inf. Process.;;
+ACM Transactions on Asian and Low-Resource Language Information Processing;ACM Trans. Asian Low-Resour. Lang. Inf. Process.;;
+ACM Transactions on Autonomous and Adaptive Systems;ACM Trans. Auton. Adapt. Syst.;;
+ACM Transactions on Computer Systems;ACM Trans. Comput. Syst.;;
+ACM Transactions on Computer-Human Interaction;ACM Trans. Comput.-Hum. Interact.;;
+ACM Transactions on Computing Education;ACM Trans. Comput. Educ.;;
+ACM Transactions on Design Automation of Electronic Systems;ACM Trans. Des. Autom. Electron. Syst.;;
+ACM Transactions on Embedded Computing Systems;ACM Trans. Embedded Comput. Syst.;;
+ACM Transactions on Graphics;ACM Trans. Graphics;;
+ACM Transactions on Information Systems;ACM Trans. Inf. Syst.;;
+ACM Transactions on Information and System Security;ACM Trans. Inf. Syst. Secur.;;
+ACM Transactions on Intelligent Systems and Technology;ACM Trans. Intell. Syst. Technol.;;
+ACM Transactions on Interactive Intelligent Systems;ACM Trans. Interact. Intell. Syst.;;
+ACM Transactions on Internet Technology;ACM Trans. Internet Technol.;;
+ACM Transactions on Knowledge Discovery from Data;ACM Trans. Knowl. Discovery Data;;
+ACM Transactions on Management Information Systems;ACM Trans. Manage. Inf. Syst.;;
+ACM Transactions on Mathematical Software;ACM Trans. Math. Software;;
+ACM Transactions on Multimedia Computing Communications and Applications;ACM Trans. Multimedia Comput. Commun. Appl.;;
+ACM Transactions on Parallel Computing;ACM Trans. Parallel Comput.;;
+ACM Transactions on Programming Languages and Systems;ACM Trans. Program. Lang. Syst.;;
+ACM Transactions on Reconfigurable Technology and Systems;ACM Trans. Reconfigurable Technol. Syst.;;
+ACM Transactions on Sensor Networks;ACM Trans. Sens. Netw.;;
+ACM Transactions on Software Engineering and Methodology;ACM Trans. Software Eng. Method.;;
+ACM Transactions on Speech and Language Processing;ACM Trans. Speech Lang. Process.;;
+ACM Transactions on Storage;ACM Trans. Storage;;
+ACM Transactions on the Web;ACM Trans. Web;;
+ACS Chemical Biology;ACS Chem. Biol.
+ACS Nano;ACS Nano
+ACS Symposium Series;ACS Symp. Ser.
+AIChE Journal;AIChE J.
+AIChE Symposium Series;AIChE Symp. Ser.
+AIP Conference Proceedings;AIP Conf. Proc.
+APL: Organic Electronics and Photonics;APL: Org. Electron. Photonics;;
+ARKIVOC (Gainesville, FL, United States);ARKIVOC (Gainesville, FL, U. S.)
+ASTM Special Technical Publication;ASTM Spec. Tech. Publ.
+ASTRA Proceedings;ASTRA Proc.;;
+ATLA, Alternatives to Laboratory Animals;ATLA, Altern. Lab. Anim.
 Abhandlungen aus dem Westfälischen Museum für Naturkunde;Abh. Westfäl. Mus. Nat.kd.
+Abhandlungen der Akademie der Wissenschaften der DDR;Abh. Akad. Wiss. DDR;;
+Abhandlungen der Akademie der Wissenschaften der DDR, Abteilung Mathematik, Naturwissenschaften, Technik;Abh. Akad. Wiss. DDR, Abt. Math., Naturwiss., Tech.;;
 Abhandlungen der Naturforschenden Gesellschaft in Zürich;Abh. Nat.forsch. Ges. Zür.
 Abhandlungen des Naturwissenschaftlichen Vereins zu Bremen;Abh. Nat.wiss. Ver. Bremen
 Abstracta Botanica;Abstr. Bot.
 Academia;Academia
 Accounts of Chemical Research;Acc. Chem. Res.
-ACH - Models in Chemistry;ACH - Models Chem.
-ACI Materials Journal;ACI Mater. J.
-ACS Chemical Biology;ACS Chem. Biol.
-ACS Nano;ACS Nano
-ACS Symposium Series;ACS Symp. Ser.
+Achievements in the Life Sciences;Achiev. Life Sci.;;
+Acoustical Science and Technology;Acoust. Sci. Technol.;;
 Acta Agralia Fennica;Acta Agral. Fenn.
 Acta Agraria et Silvestria, Seria Lesna, Krakau;Acta Agrar. Silv., Ser. Lesn. (Krak.)
 Acta Anatomica;Acta Anat.
@@ -26,6 +74,7 @@ Acta Chimica Hungarica;Acta Chim. Hung.
 Acta Chimica Sinica;Acta Chim. Sinica
 Acta Chimica Slovenica;Acta Chim. Slov.
 Acta Cienceia Indica Chemistry;Acta Cienc. Indica, Chem.
+Acta Ciencia Indica Chemistry;Acta Cienc. Indica, Chem.;;
 Acta Ciencia Indica Phyics;Acta Cienc. Indica, Phys.
 Acta Crystallographica, Section A: Foundations of Crystallography;Acta Crystallogr., Sect. A: Found. Crystallogr.
 Acta Crystallographica, Section B: Structural Science;Acta Crystallogr., Sect. B: Struct. Sci.
@@ -35,6 +84,7 @@ Acta Crystallographica, Section E: Structure Reports Online;Acta Crystallogr., S
 Acta Crystallographica, Section F: Structural Biology and Crystallization Communications;Acta Crystallogr., Sect. F: Struct. Biol. Cryst. Commun.
 Acta Endocrinologica;Acta Endocrinol.
 Acta Forestalia Fennica;Acta For. Fenn.
+Acta Geodaetica et Geophysica;Acta Geod. Geophys.;;
 Acta Geographica Sinica;Acta Geogr. Sin.
 Acta Horticulturae;Acta Hortic.
 Acta Hydrochimica et Hydrobiologica;Acta Hydrochim. Hydrobiol.
@@ -46,6 +96,7 @@ Acta Metallurgica;Acta Metall.
 Acta Metallurgica et Materialia;Acta Metall. Mater.
 Acta Oecologica;Acta Oecol.
 Acta Palaeobotanica;Acta Palaeobot.
+Acta Palaeontologica Polonica;Acta Palaeontol. Polonica;;
 Acta Pharmaceutica (Zagreb, Croatia);Acta Pharm. (Zagreb, Croatia)
 Acta Pharmacologica Sinica;Acta Pharmacol. Sin.
 Acta Physica Polonica, A;Acta Phys. Pol., A
@@ -58,24 +109,30 @@ Acta Phytopathologica et Entomologica Hungarica;Acta Phytopathol. Entomol. Hung.
 Acta Polymerica;Acta Polym.
 Acta Polytechnica Scandinavica - Chemical Technology Series;Acta Polytech. Scand., Chem. Technol. Ser
 Acta Protozoologica;Acta Protozool.
-Acta scientiarum naturalium Academiae scientiarum Bohemoslovaca;Acta sci. nat. Acad. sci. Bohemoslov.
 Acta Societatis Botanicorum Poloniae;Acta Soc. Bot. Pol.
 Acta Societatis pro Fauna et Flora Fennica;Acta Soc. Fauna Flora Fenn.
 Acta Theriologica;Acta Theriol.
+Acta scientiarum naturalium Academiae scientiarum Bohemoslovaca;Acta sci. nat. Acad. sci. Bohemoslov.
 Actes de la Société helvétique des sciences naturelles;Actes Soc. helv. sci. nat.
 Actes de la Société jurassienne d'émulation;Actes Soc. jura. émul.
 Actualite Chimique;Actual. Chim.
+Additive Manufacturing;Addit. Manuf.;;
 Adhesives Age;Adhes. Age
 Adsorption;Adsorption
 Adsorption Science & Technology;Adsorpt. Sci. Technol.
 Advanced Composite Materials;Adv. Compos. Mater
+Advanced Device Materials;Adv. Device Mater.;;
 Advanced Drug Delivery Reviews;Adv. Drug Delivery Rev.
 Advanced Engineering Materials;Adv. Eng. Mater.
 Advanced Functional Materials;Adv. Funct. Mater.
+Advanced Manufacturing: Polymer & Composites Science;Adv. Manuf. Polym. Compos. Sci.;;
 Advanced Materials (Weinheim, Germany);Adv. Mater. (Weinheim, Ger.)
+Advanced Materials Forum;Adv. Mater. Forum;;
 Advanced Materials and Processes;Adv. Mater. Processes
 Advanced Materials for Optics and Electronics;Adv. Mater. Opt. Electron.
 Advanced Powder Technology;Adv. Powder Technol.
+Advanced Robotics;Adv. Rob.;;
+Advanced Science;Adv. Sci.;;
 Advanced Synthesis & Catalysis;Adv. Synth. Catal.
 Advances in Agronomy;Adv. Agron.
 Advances in Applied Ceramics;Adv. Appl. Ceram.
@@ -85,31 +142,42 @@ Advances in Atomic, Molecular, and Optical Physics;Adv. At., Mol., Opt. Phys.
 Advances in Behavioral Biology;Adv. Behav. Biol.
 Advances in Biochemical Engineering / Biotechnology;Adv. Biochem. Eng./Biotechnol.
 Advances in Biophysics;Adv. Biophys.
+Advances in Building Energy Research;Adv. Build. Energy Res.;;
 Advances in Carbohydrate Chemistry and Biochemistry;Adv. Carbohydr. Chem. Biochem.
 Advances in Catalysis;Adv. Catal.
+Advances in Cement Research;Adv. Cem. Res.;;
 Advances in Chemical Physics;Adv. Chem. Phys.
-Advances in Chemistry Series;Adv. Chem. Ser.
 Advances in Chemistry Series;Adv. Chem. Ser.
 Advances in Chromatography (Boca Raton, FL, United States);Adv. Chromatogr. (Boca Raton, FL, U. S.)
 Advances in Chromatography (New York, NY, United States);Adv. Chromatogr. (N. Y., NY, U. S.)
+Advances in Climate Change Research;Adv. Clim. Change Res.;;
 Advances in Colloid and Interface Science;Adv. Colloid Interface Sci.
 Advances in Cryogenic Engineering;Adv. Cryog. Eng.
 Advances in Ecological Research;Adv. Ecol. Res.
 Advances in Electrochemical Science and Engineering;Adv. Electrochem. Sci. Eng.
+Advances in Engineering Education;Adv. Eng. Educ.;;
 Advances in Enzyme Regulation;Adv. Enzyme Regul.
 Advances in Enzymology and Related Areas of Molecular Biology;Adv. Enzymol. Relat. Areas Mol. Biol.
 Advances in Ethology;Adv. Ethol.
 Advances in Experimental Medicine and Biology;Adv. Exp. Med. Biol.
 Advances in Filtration and Separation Technology;Adv. Filtr. Sep. Technol.
+Advances in Geosciences;Adv. Geosci.;;
 Advances in Heterocyclic Chemistry;Adv. Heterocycl. Chem.
 Advances in Hydrogen Energy;Adv. Hydrogen Energy
 Advances in Inorganic Chemistry;Adv. Inorg. Chem.
 Advances in Instrumentation and Control;Adv. Instrum. Control
+Advances in Limnology;Adv. Limnol.;;
 Advances in Lipid Research;Adv. Lipid Res.
 Advances in Magnetic and Optical Resonance;Adv. Magn. Opt. Reson.
 Advances in Mass Spectrometry;Adv. Mass Spectrom.
 Advances in Materials Research;Adv. Mater. Res.
+Advances in Mechanics;Adv. Mech.;;
+Advances in Medical Science;Adv. Med. Sci.;;
+Advances in Modelling and Analysis A;Adv. Modell. Anal. A;;
+Advances in Modelling and Analysis B;Adv. Modell. Anal. B;;
 Advances in Molten Salt Chemistry;Adv. Molten Salt Chem.
+Advances in Oceanography and Limnology;Adv. Oceanogr. Limnol.;;
+Advances in OptoElectronics;Adv. OptoElectron.;;
 Advances in Organometallic Chemistry;Adv. Organomet. Chem.
 Advances in Photochemistry;Adv. Photochem.
 Advances in Physical Organic Chemistry;Adv. Phys. Org. Chem.
@@ -121,42 +189,56 @@ Advances in Powder Metallurgy and Particulate Materials;Adv. Powder. Metall. Par
 Advances in Prostaglandin, Thromboxane, and Leukotriene Research;Adv. Prostaglandin, Thromboxane, Leukotriene Res.
 Advances in Protein Chemistry;Adv. Protein Chem.
 Advances in Quantum Chemistry;Adv. Quantum Chem.
+Advances in Radio Science;Adv. Radio Sci.;;
+Advances in Science and Research;Adv. Sci. Res.;;
 Advances in Second Messenger and Phosphoprotein Research;Adv. Second Messenger Phosphoprotein Res.
 Advances in Space Research;Adv. Space Res.
-Advances in Space Research;Adv. Space Res.
 Advances in Spectroscopy;Adv. Spectrosc.
+Advances in Statistical Climatology, Meteorology and Oceanography;Adv. Stat. Climatol. Meteorol. Oceanogr.;;
+Advances in Structural Engineering;Adv. Struct. Eng.;;
+Advances in Transportation Studies;Adv. Transp. Stud.;;
+Advances in Water Research;Adv. Water. Res.;;
 Advances in Water Resources;Adv. Water Resour.
 Advances in X-Ray Analysis;Adv. X-Ray Anal.
 Adverse Drug Reactions and Toxicological Reviews;Adverse Drug React. Toxicol. Rev.
 Aerosol Science and Technology;Aerosol Sci. Technol.
+Aerosol and Air Quality Research;Aerosol Air Qual. Res.;;
 Aesthetic Surgery Journal;Aesthetic Surg. J.
 Afinidad;Afinidad
+Agal Research;Agal Res.;;
 Agents and Actions;Agents Actions
 Agents and Actions Supplements;Agents Actions Suppl.
 Aging Cell;Aging Cell
 Agricoltore ticinese;Agric. ticin.
 Agricoltura Italiana;Agric. Ital.
-Agricultural and Forest Meteorology;Agric. For. Meteorol.
 Agricultural Information Bulletin USDA Forest Service;Agric. Inf. Bull. USDA For. Serv.
 Agricultural Meteorology;Agric. Meteorol.
+Agricultural Research;Agric. Res.;;
+Agricultural Wastes;Agric. Wastes;;
+Agricultural and Food Science;Agric. Food Sci.;;
+Agricultural and Forest Meteorology;Agric. For. Meteorol.
 Agriculture Handbook;Agric. Handb.
+Agriculture and Agricultural Science Procedia;Agric. Agric. Sci. Procedia;;
+Agriculture and Environment;Agric. Environ.;;
 Agriculture, Ecosystems and Environment;Agric. Ecosyst. Environ.
 Agro-Ecosystems;Agro-Ecosyst.
 Agroforestry Systems;Agrofor. Syst.
 Agrokemia es Talajtan;Agrokem. Talajtan
 Agrokhimiya;Agrokhimiya
 Agronomy Journal;Agron. J.
-AIChE Journal;AIChE J.
-AIChE Symposium Series;AIChE Symp. Ser.
-AIP Conference Proceedings;AIP Conf. Proc.
+Ain Shams Engineering Journal;Ain Shams Eng. J.;;
 Al servizio del bosco e del paesaggio;Al serv. bosco paesaggio
 Alcohol (New York);Alcohol (N.Y.)
 Alcohol and Alcoholism;Alcohol Alcohol.
+Alcoholism and Drug Addiction;Alcohol Drug Addict.;;
+Algorithms for Molecular Biology;Algorithms Mol. Biol.;;
+Alimentary Pharmacology & Therapeutics;Aliment. Pharmacol. Ther.;;
 Allgemeine Forst Zeitschrift für Waldwirtschaft und Umweltvorsorge [AFZ-Der Wald];Allg. Forst Z. Waldwirtsch. Umweltvorsorge
 Allgemeine Forst- und Jagdzeitung;Allg. Forst- Jagdztg.
 Allgemeine Forstzeitung;Allg. Forstztg. (Wien)
 Allionia;Allionia
 Alpen, Die;Alpen
+Alpine Botany;Alp. Bot.;;
 Aluminium (Duesseldorf);Aluminium (Duesseldorf)
 Aluminum Transactions;Alum. Trans.
 Ambio;Ambio
@@ -171,12 +253,14 @@ American Journal of Clinical Nutrition;Am. J. Clin. Nutr.
 American Journal of Food Technology;Am. J. Food Technol.
 American Journal of Human Genetics;Am. J. Hum. Genet.
 American Journal of Hypertension;Am. J. Hypertens.
+American Journal of Neuroprotection and Neuroregeneration;Am. J. Neuroprot. Neuroregener.;;
+American Journal of Nuclear Medicine and Molecular Imaging;Am. J. Nucl. Med. Mol. Imaging;;
 American Journal of Obstetrics and Gynecology;Am. J. Obstet. Gynecol.
 American Journal of Pathology;Am. J. Pathol.
 American Journal of Pharmacology and Toxicology;Am. J. Pharmacol. Toxicol.
 American Journal of Physiology;Am. J. Physiol.
+American Journal of Plant Science;Am. J. Plant Sci.;;
 American Journal of Respiratory Cell and Molecular Biology;Am. J. Respir. Cell Mol. Biol.
-American Journal of Science;Am. J. Sci.
 American Journal of Science;Am. J. Sci.
 American Journal of Veterinary Research;Am. J. Vet. Res.
 American Laboratory;Am. Lab.
@@ -190,22 +274,24 @@ Amino Acids;Amino Acids
 Ammonia Plant Safety and Related Facilities;Ammonia Plant Saf. Relat. Facil
 Aménagement du territoire;Aménage. territ.
 Anais da Academia Brasileira de Ciencias;An. Acad. Bras. Cienc.
+Anal. Chem. Indian Journal of Chemistry, Section A: Inorganic, Bio-inorganic, Physical, Theoretical & Analytical Chemistry;Indian J. Chem., Sect. A: Inorg., Bio-inorg., Phys., Theor.;;
 Anales de Bromatologia;An. Bromatol
-Anales de la Asociacion Quimica Argentina;An. Asoc. Quim. Argent.
 Anales de Quimica;An. Quim.
+Anales de la Asociacion Quimica Argentina;An. Asoc. Quim. Argent.
 Analusis;Analusis
 Analyst (Cambridge, United Kingdom);Analyst (Cambridge, U. K.)
 Analytica Chimica Acta;Anal. Chim. Acta
-Analytical and Bioanalytical Chemistry;Anal. Bioanal. Chem.
 Analytical Biochemistry;Anal. Biochem.
-Analytical Chemistry (Washington, DC, United States);Anal. Chem. (Washington, DC, U. S.)
 Analytical Chemistry;Anal. Chem.
+Analytical Chemistry (Washington, DC, United States);Anal. Chem. (Washington, DC, U. S.)
+Analytical Chemistry Research;Anal. Chem. Res.;;
 Analytical Chemistry Symposia Series;Anal. Chem. Symp. Ser.
 Analytical Communications;Anal. Commun.
 Analytical Letters;Anal. Lett.
 Analytical Proceedings;Anal. Proc. (London)
 Analytical Sciences;Anal. Sci.
 Analytical Sciences: X-Ray Structure Analysis Online;Anal. Sci.: X-Ray Struct. Anal. Online
+Analytical and Bioanalytical Chemistry;Anal. Bioanal. Chem.
 Anatomischer Anzeiger;Anat. Anz.
 Anesthesiology;Anesthesiology
 Angewandte Botanik;Angew. Bot.
@@ -217,25 +303,28 @@ Angewandte Landschaftsökologie;Angew. Landsch.ökol.
 Angewandte Makromolekulare Chemie;Angew. Makromol. Chem.
 Angewandte Pflanzensoziologie;Angew. Pflanzensoziol.
 Animal Behaviour;Anim. Behav.
+Animal Biotelemetry;Anim. Biotelem.;;
 Animal Science and Technology;Anim. Sci. Technol.
 Animal Welfare;Anim. Welfare
 Animal Welfare Information Center Bulletin;Anim. Welfare Inf. Cent. Bull.
 Annalen der Meteorologie;Ann. Meteorol.
 Annalen der Schweizerischen meteorologischen Anstalt;Ann. Schweiz. meteorol. Anst.
-Annales agronomiques;Ann. agron.
 Annales Botanici Fennici;Ann. Bot. Fenn.
+Annales Henri Poincaré;Ann. Henri Poincaré;;
+Annales Historico-Naturales Musei Nationalis Hungarici;Ann. Hist.-Nat. Mus. Natl. Hung.
+Annales Pharmaceutiques Francaises;Ann. Pharm. Fr.
+Annales Zoologici Fennici;Ann. Zool. Fenn.
+Annales agronomiques;Ann. agron.
 Annales de Biologie Clinique;Ann. Biol. Clin.
 Annales de Biologie Clinique du Quebec;Ann. Biol. Clin. Que.
 Annales de Chimie (Cachan, France);Ann. Chim. (Cachan, Fr.)
 Annales de Chimie (Paris, France);Ann. Chim. (Paris, Fr.)
 Annales de Chimie - Science des Materiaux;Ann. Chim. - Sci. Mat.
+Annales de Limnologie;Ann. Limnol.;;
+Annales de Toxicologie Analytique;Ann. Toxicol. Anal.
 Annales de l’École nationale des eaux et forêts et de la station de recherches et expériences forestières;Ann. Éc. Natl. Eaux For.
 Annales de phytopathologie;Ann. phytopathol.
-Annales de Toxicologie Analytique;Ann. Toxicol. Anal.
 Annales des sciences forestières;Ann. sci. for.
-Annales Historico-Naturales Musei Nationalis Hungarici;Ann. Hist.-Nat. Mus. Natl. Hung.
-Annales Pharmaceutiques Francaises;Ann. Pharm. Fr.
-Annales Zoologici Fennici;Ann. Zool. Fenn.
 Annali Accademia Italiana di Scienze Forestali;Ann. Accad. Ital. Sci. For.
 Annali della Sperimentazione Agraria;Ann. Sper. Agrar.
 Annali dell’Istituto Sperimentale per la Selvicoltura;Ann. Ist. Sper. Selvic.
@@ -245,6 +334,7 @@ Annals of Applied Biology;Ann. Appl. Biol.
 Annals of Biomedical Engineering;Ann. Biomed. Eng.
 Annals of Botany;Ann. Bot.
 Annals of Clinical Biochemistry;Ann. Clin. Biochem.
+Annals of Clinical and Translational Neurology;Ann. Clin. Transl. Neurol.;;
 Annals of Forest Science;Ann. For. Sci.
 Annals of Glaciology;Ann. Glaciol.
 Annals of Internal Medicine;Ann. Intern. Med.
@@ -254,6 +344,7 @@ Annals of Nutrition & Metabolism;Ann. Nutr. Metab.
 Annals of Physics (Oxford, United Kingdom);Ann. Phys. (Oxford, U. K.)
 Annals of Physics (San Diego, CA, United States);Ann. Phys. (San Diego, CA, U. S.)
 Annals of Plastic Surgery;Ann. Plast. Surg.
+Annals of Solid and Structural Mechanics;Ann. Solid Struct. Mech.;;
 Annals of Statistics;Ann. Stat.
 Annals of the Association of American Geographers;Ann. Assoc. Am. Geogr.
 Annals of the Entomological Society of America;Ann. Entomol. Soc. Am.
@@ -265,6 +356,8 @@ Annual Reports on NMR Spectroscopy;Annu. Rep. NMR Spectrosc.
 Annual Reports on the Progress of Chemistry, Section A: Inorganic Chemistry;Annu. Rep. Prog. Chem., Sect. A: Inorg. Chem.
 Annual Reports on the Progress of Chemistry, Section B: Organic Chemistry;Annu. Rep. Prog. Chem., Sect. B: Org. Chem.
 Annual Reports on the Progress of Chemistry, Section C: Physical Chemistry;Annu. Rep. Prog. Chem., Sect. C: Phys. Chem.
+Annual Review of Analytical Chemistry;Annu. Rev. Anal. Chem.;;
+Annual Review of Animal Biosciences;Annu. Rev. Anim. Biosci.;;
 Annual Review of Biochemistry;Annu. Rev. Biochem.
 Annual Review of Biomedical Engineering;Annu. Rev. Biomed. Eng.
 Annual Review of Biophysics and Biomolecular Structure;Annu. Rev. Biophys. Biomol. Struct.
@@ -272,8 +365,10 @@ Annual Review of Cell and Developmental Biology;Annu. Rev. Cell Dev. Biol.
 Annual Review of Earth and Planetary Science Letters;Annu. Rev. Earth Planet. Sci. Lett.
 Annual Review of Earth and Planetary Sciences;Annu. Rev. Earth Planet. Sci.
 Annual Review of Ecology and Systematics;Annu. Rev. Ecol. Syst.
+Annual Review of Ecology, Evolution, and Systematics;Annu. Rev. Ecol. Evol. Syst.;;
 Annual Review of Energy and the Environment;Annu. Rev. Energy Env.
 Annual Review of Entomology;Annu. Rev. Entomol.
+Annual Review of Environment and Resources;Annu. Rev. Environ. Resour.;;
 Annual Review of Genetics;Annu. Rev. Genet.
 Annual Review of Genomics and Human Genetics;Annu. Rev. Genomics Hum. Genet.
 Annual Review of Immunology;Annu. Rev. Immunol.
@@ -294,6 +389,7 @@ Annual Review of Plant Physiology;Annu. Rev. Plant Physiol.
 Anti-Cancer Agents in Medicinal Chemistry;Anti-Cancer Agents Med. Chem.
 Anti-Cancer Drug Design;Anti-Cancer Drug Des.
 Anti-Cancer Drugs;Anti-Cancer Drugs
+Anti-Corrosion Methods and Materials;Anti-Corros. Methods Mater.;;
 Anti-Infective Agents in Medicinal Chemistry;Anti-Infect. Agents Med. Chem.
 Anti-Inflammatory & Anti-Allergy Agents in Medicinal Chemistry;Anti-Inflammatory Anti-Allergy Agents Med. Chem.
 Antibiotiki i Khimioterapiya;Antibiot. Khimioter.
@@ -306,10 +402,12 @@ Antiviral Chemistry & Chemotherapy;Antiviral Chem. Chemother.
 Antiviral Research;Antiviral Res.
 Anzeiger für Schädlingskunde, Pflanzenschutz, Umweltschutz;Anz. Schädl.kd. Pflanzenschutz Umweltschutz
 Appita Journal;Appita J.
-Applied and Environmental Microbiology;Appl. Environ. Microbiol.
+Applications in Plant Sciences;Appl. Plant Sci.;;
+Applied Adhesion Science;Appl. Adhes. Sci.;;
+Applied Artifical Intelligence;Appl. Artif. Intell.;;
 Applied Biochemistry and Biotechnology;Appl. Biochem. Biotechnol.
-Applied Biochemistry and Microbiology (Translation of Prikladnaya Biokhimiya i Mikrobiologiya);Appl. Biochem. Microbiol.
 Applied Biochemistry and Microbiology;Appl. Biochem. Microbiol.
+Applied Biochemistry and Microbiology (Translation of Prikladnaya Biokhimiya i Mikrobiologiya);Appl. Biochem. Microbiol.
 Applied Catalysis, A: General;Appl. Catal., A
 Applied Catalysis, B: Environmental;Appl. Catal., B
 Applied Clay Science;Appl. Clay Sci.
@@ -318,18 +416,21 @@ Applied Ecology Abstracts;Appl. Ecol. Abstr.
 Applied Geochemistry;Appl. Geochem.
 Applied Geography and Development;Appl. Geogr. Dev.
 Applied Magnetic Resonance;Appl. Magn. Reson.
+Applied Mathematics Research eXpress;Appl. Math. Res. eXpress;;
 Applied Microbiology and Biotechnology;Appl. Microbiol. Biotechnol.
 Applied Occupational and Environmental Hygiene;Appl. Occup. Environ. Hyg.
 Applied Optics;Appl. Opt.
-Applied Optics;Appl. Opt.
 Applied Organometallic Chemistry;Appl. Organomet. Chem.
+Applied Petrochemical Research;Appl. Petrochem. Res.;;
 Applied Physics A: Materials Science & Processing;Appl. Phys. A: Mater. Sci. Process.
 Applied Physics A: Solids and Surfaces;Appl. Phys. A
 Applied Physics B: Lasers and Optics;Appl. Phys. B: Lasers Opt.
 Applied Physics B: Photophysics and Laser Chemistry;Appl. Phys. B
 Applied Physics Letters;Appl. Phys. Lett.
+Applied Polymer Composites;Appl. Polym. Compos.;;
 Applied Radiation and Isotopes;Appl. Radiat. Isot.
 Applied Scientific Research;Appl. Sci. Res.
+Applied Soil Ecology;Appl. Soil Ecol.;;
 Applied Spectroscopy;Appl. Spectrosc.
 Applied Spectroscopy Reviews;Appl. Spectrosc. Rev.
 Applied Statistics;Appl. Stat.
@@ -337,15 +438,21 @@ Applied Superconductivity;Appl. Supercond.
 Applied Surface Science;Appl. Surf. Sci.
 Applied Thermal Engineering;Appl. Therm. Eng.
 Applied Vegetation Science;Appl. Veg. Sci.
+Applied Water Science;Appl. Water Sci.;;
+Applied and Environmental Microbiology;Appl. Environ. Microbiol.
 Aquacultural Engineering;Aquacult. Eng.
 Aquaculture;Aquaculture
 Aquaculture International;Aquacult. Int.
 Aquaculture Nutrition;Aquacult. Nutr.
+Aquaculture Reports;Aquacult. Rep.;;
 Aquaculture Research;Aquacult. Res.
+Aquatic Biosystems;Aquat. Biosyst.;;
 Aquatic Botany;Aquat. Bot.
+Aquatic Conservation: Marine and Freshwater Ecosystems;Aquat. Conserv. Mar. Freshwater Ecosyst.;;
 Aquatic Sciences;Aquat. Sci.
 Aquatic Toxicology;Aquat. Toxicol.
 Arachnologische Mitteilungen;Arachnol. Mitt.
+Arbeiten aus dem Anatomischen Institut der Kaiserlich-Japanischen Universitaet zu Sendai;Arb. Anat. Inst. Kais.-Jpn. Univ. Sendai;;
 Arboricultural Journal;Arboric. J.
 Archaea;Archaea
 Archiv der Pharmazie (Weinheim, Germany);Arch. Pharm. (Weinheim, Ger.)
@@ -368,41 +475,48 @@ Archivum Combustionis;Arch. Combust.
 Archivum Societatis Zoologicae Botanicae Fennicae Vanamo;Arch. Soc. Zool. Bot. Fenn. Vanamo
 Archäologie der Schweiz;Archäol. Schweiz
 Archéologie neuchâteloise;Archéol. neuchâtel.
+Arctic Science;Arct. Sci.;;
 Arctic, Antarctic, and Alpine Research;Arct., Antarc., Alp. Res.
 Ardea;Ardea
 Arealstatistik der Schweiz;Arealstat. Schweiz
-ARKIVOC (Gainesville, FL, United States);ARKIVOC (Gainesville, FL, U. S.)
 Armyanskii Khimicheskii Zhurnal;Arm. Khim. Zh.
+Arrhythmia & Electrophysiology Review;Arrhythmia Electrophysiol. Rev.;;
 Arteriosclerosis and Thrombosis;Arterioscler. Thromb.
 Arteriosclerosis, Thrombosis, and Vascular Biology;Arterioscler., Thromb., Vasc. Biol.
 Artificial Cells Blood Substitutes and Immobilization Biotechnology;Artif. Cells, Blood Substitues, Immobilization Biotechnol.
 Arzneimittel Forschung;Arzneim. Forsch.
 Arzneimittel-Forschung/Drug Research;Arzneim.-Forsch.
+Asia Pacific Journal of Medical Toxicology;Asia Pac. J. Med. Toxicol.;;
 Asia-Pacific Journal of Chemical Engineering;Asia-Pac. J. Chem. Eng.
+Asian Journal of Atmospheric Environment;Asian J. Atmos. Environ.;;
 Asian Journal of Biochemistry;Asian J. Biochem.
 Asian Journal of Chemistry;Asian J. Chem.
 Asian Journal of Spectroscopy;Asian J. Spectro.
 Aspects of Homogeneous Catalysis;Aspects Homogeneous Catal.
 Assay and Drug Development Technologies;Assay Drug Dev. Technol.
-ASTM Special Technical Publication;ASTM Spec. Tech. Publ.
 Astrofizika;Astrofizika
 Astronomical Journal;Astron. J.
 Astronomicheskii Zhurnal;Astron. Zh.
 Astronomische Nachrichten;Astron. Nachr.
 Astronomy & Astrophysics, Supplement Series;Astron. Astrophys., Suppl. Ser.
-Astronomy and Astrophysics;Astron. Astrophys.
 Astronomy Letters;Astron. Lett.
+Astronomy and Astrophysics;Astron. Astrophys.
+Astronomy and Computing;Astron. Comput.;;
 Astrophysical Journal;Astrophys. J.
-Astrophysics and Space Science;Astrophys. Space Sci.
-Astrophysics and Space Science Library;Astrophys. Space Sci. Libr.
+Astrophysical Journal Supplement Series;Astrophys. J. Suppl. Ser.;;
 Astrophysics Journal;Astrophys. J.
 Astrophysics Journal Supplement Series;Astrophys. J. Suppl. Ser.
+Astrophysics and Space Science;Astrophys. Space Sci.
+Astrophysics and Space Science Library;Astrophys. Space Sci. Libr.
+Astrophysics and Space Science Transactions;Astrophys. Space Sci. Trans;;
 Atherosclerosis (Amsterdam, Netherlands);Atherosclerosis (Amsterdam, Neth.)
 Atherosclerosis (Shannon, Ireland);Atherosclerosis (Shannon, Irel.)
-ATLA, Alternatives to Laboratory Animals;ATLA, Altern. Lab. Anim.
 Atmospheric Chemistry and Physics;Atmos. Chem. Phys.
 Atmospheric Environment;Atmos. Environ.
 Atmospheric Environment, Part A: General Topics;Atmos. Environ., Part A
+Atmospheric EnvironmentPart A General Topics;Atmos. Environ. Part A;;
+Atmospheric EnvironmentPart B Urban Atmosphere;Atmos. Environ. Part B;;
+Atmospheric Measurement Techniques Discussions;Atmos. Meas. Tech. Discuss.;;
 Atmospheric Research;Atmos. Res.
 Atomic Data and Nuclear Data Tables;At. Data Nucl. Data Tables
 Atomic Energy (New York, NY, United States);At. Energy (N. Y., NY, U. S.)
@@ -411,17 +525,31 @@ Atomization and Sprays;Atomization Sprays
 Atomnaya Energiya;At. Energ.
 Augsburger Ökologische Schriften;Augsbg. Ökol. Schr.
 Auk, The;Auk
+Australasian Physical & Engineering Sciences in Medicine;Australas. Phys. Eng. Sci. Med.;;
 Australasian Plant Pathology;Australas. Plant Pathol.
 Australian Forest Research;Aust. For. Res.
+Australian Geomechanics Journal;Aust. Geomech. J.;;
+Australian Journal of Agricultural and Resource Economics;Aust. J. Agric. Resour. Econ.;;
 Australian Journal of Botany;Aust. J. Bot.
 Australian Journal of Chemistry;Aust. J. Chem.
+Australian Journal of Civil Engineering;Aust. J. Civil Eng.;;
 Australian Journal of Ecology;Aust. J. Ecol.
 Australian Journal of Education in Chemistry;Aust. J. Edu. Chem.
+Australian Journal of Electrical and Electronics Engineering;Aust. J. Electr. Electron. Eng.;;
+Australian Journal of Forensic Sciences;Aust. J. Forensic Sci.;;
+Australian Journal of Mechanical Engineering;Aust. J. Mech. Eng.;;
 Australian Journal of Physics;Aust. J. Phys.
+Australian Journal of Structural Engineering;Aust. J. Struct. Eng.;;
+Australian Journal of Water Resources;Aust. J. Water Resour.;;
+Australian Meteorological and Oceanographic Journal;Aust. Meteorol. Oceanogr. J.;;
+Austrian Journal of Earth Sciences;Austrian J. Earth Sci.;;
+Austrian Journal of Forest Science;Austrian J. For. Sci.;;
 Autonomic & Autacoid Pharmacology;Auton. Autacoid Pharmacol.
+Avian Biology Research;Avian Biol. Res.;;
 Avicultural Magazine;Avic. Mag.
 Avtomaticheskaya Svarka;Avtom. Svarka
 Azerbaidzhanskii Khimicheskii Zhurnal;Azerb. Khim. Zh.
+BBA Clinical;BBA Clin.;;
 Badener Neujahrsblätter;Baden. Neujahrsbl.
 Bandaoti Xuebao;Bandaoti Xuebao
 Basic & Clinical Pharmacology & Toxicology;Basic Clin. Pharmacol. Toxicol.
@@ -432,34 +560,38 @@ Bauhinia;Bauhinia
 Behavioural Ecology;Behav. Ecol.
 Behavioural Ecology and Sociobiology;Behav. Ecol. Sociobiol.
 Behavioural Pharmacology;Behav. Pharmacol.
+Beiheft zu Nova Hedwigia;Beih. Nova Hedwigia
 Beiheft zu den Annalen der Schweizerischen meteorologischen Anstalt;Beih. Ann. Schweiz. meteorol. Anst.
 Beiheft zu den Zeitschriften des Schweiz. Forstvereins;Beih. Z. Schweiz. Forstver.
-Beiheft zu Nova Hedwigia;Beih. Nova Hedwigia
 Beiheft zum Jahrbuch der Schweizerischen naturforschenden Gesellschaft;Beih. Jahrb. Schweiz. nat.forsch. Ges.
 Beiheft zur Schweizerischen Zeitschrift für Forstwesen;Beih. Schweiz. Z. Forst.wes.
 Beiheft zur Zeitschrift für Mykologie;Beih. Z. Mykol.
 Beihefte zum Botanischen Centralblatt;Beih. Bot. Cent.bl.
 Beilstein Journal of Organic Chemistry;Beilstein J. Org. Chem.
 Beitraege zur Chemischen Physiologie und Pathologie;Beitr. Chem. Physiol. Pathol.
-Beiträge für die Forstwirtschaft;Beitr. Forstwirtsch.
+Beitrage zur Krystallographie und Mineralogie;Beitr. Kryst. Mineral.;;
 Beiträge für Forstwirtschaft und Landschaftsökologie;Beitr. Forstwirtsch. Landsch.ökol.
+Beiträge für die Forstwirtschaft;Beitr. Forstwirtsch.
 Beiträge zum Naturschutz in der Schweiz;Beitr. Nat.schutz Schweiz
 Beiträge zur Avifauna des Rheinlandes;Beitr. Avifauna Rheinl.
 Beiträge zur Biologie der Pflanzen;Beitr. Biol. Pflanzen
-Beiträge zur geobotanischen Landesaufnahme der Schweiz;Beitr. geobot. Landesaufn. Schweiz
 Beiträge zur Geologie der Schweiz: Hydrologie;Beitr. Geol. Schweiz: Hydrol.
 Beiträge zur Hydrologie der Schweiz;Beitr. Hydrol. Schweiz
 Beiträge zur Jagd- und Wildforschung;Beitr. Jagd- Wildforsch.
 Beiträge zur Kryptogamenflora der Schweiz;Beitr. Kryptogamenflora Schweiz
+Beiträge zur geobotanischen Landesaufnahme der Schweiz;Beitr. geobot. Landesaufn. Schweiz
 Beiträge zur naturkundlichen Forschung in Südwestdeutschland;Beitr. nat.kdl. Forsch. Südwestdtschl.
 Berg- und Huettenmaennische Monatshefte;Berg- Huettenmaenn. Monatsh.
+Berichte Eidg. Anstalt für das forstliche Versuchswesen;Ber. Eidgenöss. Anst. forstl. Vers.wes.
+Berichte Freiburger Forstliche Forschung;Ber. Freibg. Forstl. Forsch.
 Berichte aus der Bayerischen Landesanstalt für Wald und Forstwirtschaft;Ber. Bayer. Landesanst. Wald Forstwirtsch.
 Berichte der Akademie für Naturschutz und Landschaftspflege;Ber. Akad. Nat.schutz Landsch.pfl.
 Berichte der Botanisch-Zoologischen Gesellschaft Liechtenstein- Sargans-Werdenberg;Ber. Bot.-Zool. Ges. Liecht.-Sargans-Werdenberg
-Berichte der Bunsen-Gesellschaft für Physikalische Chemie;Ber. Bunsen-Ges. Phys. Chem.
 Berichte der Bunsen-Gesellschaft Physical Chemistry Chemical Physics;Ber. Bunsen-Ges. Phys. Chem
-Berichte der Deutschen botanischen Gesellschaft;Ber. Dtsch. bot. Ges.
+Berichte der Bunsen-Gesellschaft für Physikalische Chemie;Ber. Bunsen-Ges. Phys. Chem.
+Berichte der Deutschen Botanischen Gesellschaft;Ber. Dtsch. Bot. Ges.;;
 Berichte der Deutschen Chemischen Gesellschaft;Ber. Dtsch. Chem. Ges.
+Berichte der Deutschen botanischen Gesellschaft;Ber. Dtsch. bot. Ges.
 Berichte der Eidg. Forschungsanstalt für Wald, Schnee und Landschaft;Ber. Eidgenöss. Forsch.anst. Wald Schnee Landsch.
 Berichte der Sankt Gallischen Naturwissenschaftlichen Gesellschaft;Ber. St. Gallen Nat.wiss. Ges.
 Berichte der Schweizerischen botanischen Gesellschaft;Ber. Schweiz. bot. Ges.
@@ -469,25 +601,38 @@ Berichte des Bundesamtes für Wasser und Geologie;Ber. Bundesamt Wasser Geol.
 Berichte des Deutschen Wetterdienstes;Ber. Dtsch. Wetterd.
 Berichte des Forschungszentrums Waldökosysteme;Ber. Forsch.zent. Waldökosyst.
 Berichte des Geobotanischen Institutes der Eidg. Technischen Hochschule, Stiftung Rübel;Ber. Geobot. Inst. Eidgenöss. Tech. Hochsch., Stift. Rübel
-Berichte Eidg. Anstalt für das forstliche Versuchswesen;Ber. Eidgenöss. Anst. forstl. Vers.wes.
-Berichte Freiburger Forstliche Forschung;Ber. Freibg. Forstl. Forsch.
+Berliner Beitraege zur Archaeometrie;Berl. Beitr. Archaeom.;;
+Berliner Geowissenschaftliche Abhandlungen, Reihe A: Geologie und Palaeontologie;Berl. Geowiss. Abh., Reihe A;;
 Berner Wald;Bern. Wald
 Berner Zeitschrift für Geschichte und Heimatkunde;Bern. Z. Gesch. Heim.kd.
 Berner Zeitung;Bern. Ztg.
+Best Practice & Research: Clinical Anaesthesiology;Best Pract. Res. Clin. Anaesthesiol.;;
+Best Practice & Research: Clinical Endocrinology and Metabolism;Best Pract. Res. Clin. Endocrinol. Metab.;;
+Best Practice & Research: Clinical Gastroenterology;Best Pract. Res. Clin. Gastroenterol.;;
+Best Practice & Research: Clinical Haematology;Best Pract. Res. Clin. Haematol.;;
+Best Practice & Research: Clinical Obstetrics and Gynaecology;Best Pract. Res. Clin. Obstet. Gynaecol.;;
+Best Practice & Research: Clinical Rheumatology;Best Pract. Res. Clin. Rheumatol.;;
 Betonwerk und Fertigteil Technik;Betonwerk Fertigteil Tech
 Bi-monthly Research Notes;Bi-mon. Res. Notes
 Bibliographia Scientiae Naturalis Helvetica;Bibliogr. Sci. Nat. Helv.
 Bibliotheca Botanica;Bibl. Bot.
 Bibliotheca Lichenologica;Bibl. Lichenol.
 Bibliotheca Mycologica;Bibl. Mycol.
+Big Data;Big Data;;
+Big Data Research;Big Data Res.;;
 Bilanz;Bilanz
 Bild der Wissenschaft;Bild Wiss.
 Bildmessung und Luftbildwesen;Bildmess. Luftbildwes.
 Bio-Medical Materials and Engineering;Bio-Med. Mater. Eng.
 Bio/Technology;Bio/Technology
+BioChemistry (Rajkot, India);BioChemistry (Rajkot, India)
+BioEssays;BioEssays
+BioFactors;BioFactors
+BioMetals;BioMetals
+BioScience;BioScience
+BioTechniques;BioTechniques
+BioTechnology (Rajkot, India);BioTechnology (Rajkot, India)
 Biocatalysis and Biotransformation;Biocatal. Biotransform.
-Biochemical and Biophysical Research Communications;Biochem. Biophys. Res. Commun.
-Biochemical and Molecular Medicine;Biochem. Mol. Med.
 Biochemical Archives;Biochem. Arch.
 Biochemical Education;Biochem. Educ.
 Biochemical Engineering Journal;Biochem. Eng. J.
@@ -498,13 +643,14 @@ Biochemical Pharmacology;Biochem. Pharmacol.
 Biochemical Society Symposium;Biochem. Soc. Symp.
 Biochemical Society Transactions;Biochem. Soc. Trans.
 Biochemical Systematics and Ecology;Biochem. Syst. Ecol.
-Biochemistry (Moscow);Biochemistry (Moscow)
-BioChemistry (Rajkot, India);BioChemistry (Rajkot, India)
+Biochemical and Biophysical Research Communications;Biochem. Biophys. Res. Commun.
+Biochemical and Molecular Medicine;Biochem. Mol. Med.
 Biochemistry;Biochemistry
+Biochemistry (Moscow);Biochemistry (Moscow)
+Biochemistry International;Biochem. Int.
 Biochemistry and Cell Biology;Biochem. Cell Biol.
 Biochemistry and Molecular Biology Education;Biochem. Mol. Biol. Educ.
 Biochemistry and Molecular Biology International;Biochem. Mol. Biol. Int.
-Biochemistry International;Biochem. Int.
 Biochimica et Biophysica Acta;Biochim. Biophys. Acta
 Biochimica et Biophysica Acta, Bioenergetics;Biochim. Biophys. Acta, Bioenerg.
 Biochimica et Biophysica Acta, Biomembranes;Biochim. Biophys. Acta, Biomembr.
@@ -515,9 +661,9 @@ Biochimica et Biophysica Acta, Gene Regulatory Mechanisms;Biochim. Biophys. Acta
 Biochimica et Biophysica Acta, Gene Structure and Expression;Biochim. Biophys. Acta, Gene Struct. Expression
 Biochimica et Biophysica Acta, General Subjects;Biochim. Biophys. Acta, Gen. Subj.
 Biochimica et Biophysica Acta, Lipids and Lipid Metabolism;Biochim. Biophys. Acta, Lipids Lipid Metab.
-Biochimica et Biophysica Acta, Molecular and Cell Biology of Lipids;Biochim. Biophys. Acta, Mol. Cell Biol. Lipids
 Biochimica et Biophysica Acta, Molecular Basis of Disease;Biochim. Biophys. Acta, Mol. Basis Dis.
 Biochimica et Biophysica Acta, Molecular Cell Research;Biochim. Biophys. Acta, Mol. Cell Res.
+Biochimica et Biophysica Acta, Molecular and Cell Biology of Lipids;Biochim. Biophys. Acta, Mol. Cell Biol. Lipids
 Biochimica et Biophysica Acta, Mucoproteins and Mucopolysaccharides;Biochim. Biophys. Acta, Mucoproteins Mucopolysaccharides
 Biochimica et Biophysica Acta, Protein Structure;Biochim. Biophys. Acta, Protein Struct.
 Biochimica et Biophysica Acta, Protein Structure and Molecular Enzymology;Biochim. Biophys. Acta, Protein Struct. Mol. Enzymol.
@@ -529,17 +675,19 @@ Biochimica et Biophysica Acta, Specialized Section on Biophysical Subjects;Bioch
 Biochimica et Biophysica Acta, Specialized Section on Enzymological Subjects;Biochim. Biophys. Acta, Spec. Sect. Enzymol. Subj.
 Biochimica et Biophysica Acta, Specialized Section on Lipids and Related Subjects;Biochim. Biophys. Acta, Spec. Sect. Lipids Relat. Subj.
 Biochimie;Biochimie
+Biochip Journal;Biochip J.;;
 Bioconjugate Chemistry;Bioconjugate Chem.
-Biodiversity and Conservation;Biodivers. Conserv.
+Biodiversity Data Journal;Biodivers. Data J.;;
 Biodiversity Letters;Biodivers. Lett.
+Biodiversity and Conservation;Biodivers. Conserv.
 Bioelectrochemistry;Bioelectrochemistry
 Bioelectrochemistry and Bioenergetics;Bioelectrochem. Bioenerg.
-BioEssays;BioEssays
-BioFactors;BioFactors
+Bioenergy Research;Bioenergy Res.;;
 Biofizika;Biofizika
 Biofuels, Bioproducts & Biorefining;Biofuels, Bioprod. Biorefin.
 Biogenic Amines;Biog. Amines
 Biogeochemistry;Biogeochemistry
+Biogeosciences Discussions;Biogeosci. Discuss.;;
 Bioinformatics;Bioinformatics
 Bioinorganic Chemistry and Applications;Bioinorg. Chem. Appl.
 Bioinspiration & Biomimetics;Bioinspiration Biomimetics
@@ -553,7 +701,10 @@ Biological Invasions;Biol. Invasions
 Biological Mass Spectrometry;Biol. Mass Spectrom.
 Biological Membranes;Biol. Membr.
 Biological Reviews;Biol. Rev.
+Biological Rhythm Research;Biol. Rhythm Res.;;
+Biological Systems: Open Access;Biol. Syst. Open Access;;
 Biological Trace Element Research;Biol. Trace Elem. Res.
+Biological Wastes;Biol. Wastes;;
 Biologicheskie Membrany;Biol. Membr.
 Biologicheskie Nauki (Moscow);Biol. Nauki (Moscow)
 Biologische Rundschau;Biol. Rundsch.
@@ -561,21 +712,27 @@ Biologisches Zentralblatt;Biol. Zent.bl.
 Biology and Fertility of Soils;Biol. Fertil. Soils
 Biology of Reproduction;Biol. Reprod.
 Biomacromolecules;Biomacromolecules
+Biomarker Research;Biomarker Res.;;
 Biomarkers;Biomarkers
+Biomass Conversion and Biorefinery;Biomass Convers. Biorefin.;;
 Biomass and Bioenergy;Biomass Bioenergy
 Biomaterials;Biomaterials
+Biomed Research International;Biomed Res. Int.;;
 Biomedica Biochimica Acta;Biomed. Biochim. Acta
 Biomedical Chromatography;Biomed. Chromatogr.
+Biomedical Engineering Letters;Biomed. Eng. Lett.;;
 Biomedical Materials (Bristol, United Kingdom);Biomed. Mater. (Bristol, U. K.)
 Biomedical Microdevices;Biomed. Microdevices
+Biomedical Optics Express;Biomed. Opt. Express;;
 Biomedical Research;Biomed. Res.
 Biomedical Research on Trace Elements;Biomed. Res. Trace Elem.
 Biomeditsinskaya Khimiya;Biomed. Khim.
 Biomedizinisch Technik;Biomed. Tech.
-BioMetals;BioMetals
+Biometric Technology Today;Biom. Technol. Today;;
 Biometrics;Biometrics
 Biometrie und Informatik in der Biologie und Medizin;Biom. Inform. Biol. Med.
 Biometrika;Biometrika
+Biomolecular Detection and Quantification;Biomol. Detect. Quantif.;;
 Biomolecular Engineering;Biomol. Eng.
 Biomolecular NMR Assignments;Biomol. NMR Assignments
 Bioorganic & Medicinal Chemistry;Bioorg. Med. Chem.
@@ -587,27 +744,27 @@ Biopharmaceutics & Drug Disposition;Biopharm. Drug Dispos.
 Biophysical Chemistry;Biophys. Chem.
 Biophysical Journal;Biophys. J.
 Biopolymers;Biopolymers
-Bioprocess and Biosystems Engineering;Bioprocess Biosyst. Eng.
 Bioprocess Engineering;Bioprocess. Eng.
+Bioprocess and Biosystems Engineering;Bioprocess Biosyst. Eng.
 Bioremediation Journal;Biorem. J.
+Bioresearch Open Access;Biores. Open Access;;
 Bioresource Technology;Bioresour. Technol.
-BioScience;BioScience
 Bioscience Reports;Biosci. Rep.
 Bioscience, Biotechnology, and Biochemistry;Biosci., Biotechnol., Biochem.
 Biosensors & Bioelectronics;Biosens. Bioelectron.
 Biotechnic and Histochemistry;Biotech. Histochem.
-BioTechniques;BioTechniques
 Biotechnologie, Agronomie, Societe et Environnement;Biotechnol. Agron. Soc. Environ.
-BioTechnology (Rajkot, India);BioTechnology (Rajkot, India)
 Biotechnology Advances;Biotechnol. Adv.
+Biotechnology Journal;Biotechnol. J.
+Biotechnology Law Report;Biotechnol. Law Rep.;;
+Biotechnology Letters;Biotechnol. Lett.
+Biotechnology Progress;Biotechnol. Prog.
+Biotechnology Reports;Biotechnol. Rep,;;
+Biotechnology Techniques;Biotechnol. Tech.
 Biotechnology and Applied Biochemistry;Biotechnol. Appl. Biochem.
 Biotechnology and Bioengineering;Biotechnol. Bioeng.
 Biotechnology and Bioprocess Engineering;Biotechnol. Bioprocess Eng.
 Biotechnology and Biotechnological Equipment;Biotechnol. Biotechnol. Equip.
-Biotechnology Journal;Biotechnol. J.
-Biotechnology Letters;Biotechnol. Lett.
-Biotechnology Progress;Biotechnol. Prog.
-Biotechnology Techniques;Biotechnol. Tech.
 Biotekhnologiya;Biotekhnologiya
 Biotropica;Biotropica
 Bird Study;Bird Stud.
@@ -633,13 +790,16 @@ Botanica Helvetica;Bot. Helv.
 Botanical Gazette;Bot. Gaz.
 Botanical Journal of the Linnean Society;Bot. J. Linn. Soc.
 Botanical Magazine Tokyo;Bot. Mag. Tokyo
+Botanical Museum Leaflets, Harvard University;Bot. Mus. Leafl. Harv. Univ.;;
 Botanical Review;Bot. Rev.
 Botanische Jahrbücher für Systematik, Pflanzengeschichte und Pflanzengeographie;Bot. Jahrb. Syst. Pflanzengesch. Pflanzengeogr.
 Botanische Zeitung;Bot. Ztg.
 Botanisches Centralblatt;Bot. Cent.bl.
 Boundary-Layer Meteorology;Boundary-Layer Meteorol.
+Brain Connectivity;Brain Connect.;;
 Brain Research;Brain Res.
 Brain Research Bulletin;Brain Res. Bull.
+Brain Structure & Function;Brain Struct. Funct.;;
 Brenesia;Brenesia
 Brennstoff-Warme-Kraft;Brennst.-Warme-Kraft
 British Archaeological Reports, British Series;Br. Archaeol. Rep., Br. Ser.
@@ -649,39 +809,43 @@ British Journal of Applied Physics;Br. J. Appl. Phys.
 British Journal of Cancer;Br. J. Cancer
 British Journal of Clinical Pharmacology;Br. J. Clin. Pharmacol.
 British Journal of Industrial Medicine;Br. J. Ind. Med.
+British Journal of Medical Practitioners;Br. J. Med. Pract.;;
 British Journal of Nutrition;Br. J. Nutr.
 British Journal of Pharmacology;Br. J. Pharmacol.
 Bryologist;Bryologist
 Bulgarian Chemical Communications;Bulg. Chem. Commun.
-Bulletin angewandte Geologie;Bull. angew. Geol.
 Bulletin Bodenkundliche Gesellschaft der Schweiz;Bull. Bodenkd. Ges. Schweiz
+Bulletin Forestry Commission;Bull. For. Comm.
+Bulletin Geological Society of America;Bull. Geol. Soc. Am.
+Bulletin Geological Survey of Canada;Bull. Geol. Surv. Can.
+Bulletin Mensuel de la Société Linnéenne de Lyon;Bull. Mens. Soc. Linn. Lyon
+Bulletin Peabody Museum of Natural History, Yale University;Bull. Peabody Mus. Nat. Hist., Yale Univ.
+Bulletin Suisse de Mycologie;Bull. Suisse Mycol.
+Bulletin angewandte Geologie;Bull. angew. Geol.
 Bulletin de l'Association pour la Défense des Intérêts du Jura;Bull. Assoc. Déf. Intérêts Jura
 Bulletin de la Murithienne;Bull. Murithienne
 Bulletin de la Societe Chimique de France;Bull. Soc. Chim. Fr.
 Bulletin de la Societe Francaise de Physique;Bull. Soc. Fr. Phys.
 Bulletin de la Societe Geologique de France;Bull. Soc. Geol. Fr.
 Bulletin de la Société Botanique de France;Bull. Soc. Bot. Fr.
-Bulletin de la Société entomologique de France;Bull. Soc. entomol. Fr.
-Bulletin de la société entomologique Suisse;Bull. soc. entomol. Suisse
-Bulletin de la Société française de photogrammétrie et télédétection;Bull. Soc. fr. photogramm. télédétect.
-Bulletin de la société fribourgeoise des sciences naturelles;Bull. soc. fribg. sci. nat.
 Bulletin de la Société Géologique de France;Bull. Soc. Géol. Fr.
-Bulletin de la Société mycologique de France;Bull. Soc. mycol. Fr.
-Bulletin de la société neuchâteloise des sciences naturelles;Bull. soc. neuchâtel. sci. nat.
-Bulletin de la Société royale forestière de Belgique;Bull. Soc. r. for. Belg.
 Bulletin de la Société Vaudoise des sciences naturelles;Bull. Soc. Vaud. sci. nat.
+Bulletin de la Société entomologique de France;Bull. Soc. entomol. Fr.
+Bulletin de la Société française de photogrammétrie et télédétection;Bull. Soc. fr. photogramm. télédétect.
+Bulletin de la Société mycologique de France;Bull. Soc. mycol. Fr.
+Bulletin de la Société royale forestière de Belgique;Bull. Soc. r. for. Belg.
+Bulletin de la société entomologique Suisse;Bull. soc. entomol. Suisse
+Bulletin de la société fribourgeoise des sciences naturelles;Bull. soc. fribg. sci. nat.
+Bulletin de la société neuchâteloise des sciences naturelles;Bull. soc. neuchâtel. sci. nat.
 Bulletin de vulgarisation forestière;Bull. vulg. for.
-Bulletin des recherches agronomiques de Gembloux;Bull. rech. agron. Gembloux
 Bulletin des Societes Chimiques Belges;Bull. Soc. Chim. Belg.
+Bulletin des recherches agronomiques de Gembloux;Bull. rech. agron. Gembloux
 Bulletin du Cercle Vaudois de Botanique;Bull. Cercle Vaudois Bot.
 Bulletin d’information Office national des forêts;Bull. inf. Off. natl. for.
 Bulletin d’informations techniques;Bull. inf. tech.
 Bulletin for the History of Chemistry;Bull. Hist. Chem.
-Bulletin Forestry Commission;Bull. For. Comm.
-Bulletin Geological Society of America;Bull. Geol. Soc. Am.
-Bulletin Geological Survey of Canada;Bull. Geol. Surv. Can.
-Bulletin Mensuel de la Société Linnéenne de Lyon;Bull. Mens. Soc. Linn. Lyon
 Bulletin of Animal Behaviour;Bull. Anim. Behav.
+Bulletin of Brewing Science;Bull. Brew. Sci.;;
 Bulletin of Electrochemistry;Bull. Electrochem.
 Bulletin of Environmental Contamination and Toxicology;Bull. Environ. Contam. Toxicol.
 Bulletin of Experimental Biology and Medicine;Bull. Exp. Biol. Med.
@@ -693,41 +857,49 @@ Bulletin of the British Museum of Natural History, Botany;Bull. Br. Mus. Nat. Hi
 Bulletin of the British Mycological Society;Bull. Br. Mycol. Soc.
 Bulletin of the British Ornithologists’ Club;Bull. Br. Ornithol. Club
 Bulletin of the California Agricultural Experiment Station;Bull. Calif. Agric. Exp. Stn.
+Bulletin of the Canadian Biochemical Society;Bull. Can. Biochem. Soc.;;
 Bulletin of the Chemical Society of Japan;Bull. Chem. Soc. Jpn.
 Bulletin of the Geobotanical Institute ETH;Bull. Geobot. Inst. ETH
+Bulletin of the Geological Society of China;Bull. Geol. Soc. China;;
 Bulletin of the Geological Society of Finland;Bull. Geol. Soc. Finl.
 Bulletin of the International Association of Scientific Hydrology;Bull. Int. Assoc. Sci. Hydrol.
 Bulletin of the Korean Chemical Society;Bull. Korean Chem. Soc.
+Bulletin of the Peabody Museum of Natural History;Bull. Peabody Mus. Nat. Hist.;;
 Bulletin of the Polish Academy of Sciences, Chemistry;Bull. Pol. Acad. Sci., Chem.
-Bulletin Peabody Museum of Natural History, Yale University;Bull. Peabody Mus. Nat. Hist., Yale Univ.
 Bulletin romand d'entomologie;Bull. romand entomol.
-Bulletin Suisse de Mycologie;Bull. Suisse Mycol.
 Bulletin technique de la Suisse romande;Bull. tech. Suisse romande
 Bunseki Kagaku;Bunseki Kagaku
+Burnout Research;Burnout Res.;;
 Byulleten Eksperimental'noi Biologii i Meditsiny;Byull. Eksp. Biol. Med.
 Bündner Monatsblatt;Bündner Mon.bl.
 Bündnerwald;Bündnerwald
 Bündnerwald, Beiheft;Bündnerwald, Beih.
 Bürger im Staat, Der;Bürg. Staat
+CALPHAD: Computer Coupling of Phase Diagrams and Thermochemistry;CALPHAD: Comput. Coupling Phase Diagrams Thermochem.
+CIM Bulletin;CIM Bull.
+CNS & Neurological Disorders: Drug Targets;CNS Neurol. Disord.: Drug Targets
+CPP Chemical Plants and Processing;CPP Chem. Plants and Process.
 Cadernos de Ciência e Tecnologia;Cad. Ciênc. Tecnol.
+Cadernos de Saude Publica;Cad. Saude Publica;;
 Cahier du Centre technique du bois;Cah. Cent. tech. bois
 Cahiers d'Informations Techniques / Revue de Metallurgie;Cah. Inf. Tech./Rev Metall
 Cailiao Baohu;Cailiao Baohu
 Cailiao Rechuli Xuebao;Cailiao Rechuli Xuebao
 Calcified Tissue International;Calcif. Tissue Int.
 Calorimetrie et Analyse Thermique;Calorim. Anal. Therm.
-CALPHAD: Computer Coupling of Phase Diagrams and Thermochemistry;CALPHAD: Comput. Coupling Phase Diagrams Thermochem.
+Cambridge Archaeological Journal;Cambridge Archaeol. J.;;
+Canadian Biosystems Engineering;Can. Biosyst. Eng.;;
 Canadian Ceramics Quarterly;Can. Ceram. Q.
 Canadian Chemical News;Can. Chem. News
+Canadian Chemical Processing;Can. Chem. Process.;;
 Canadian Entomologist;Can. Entomol.
 Canadian Geotechnical Journal;Can. Geotech. J.
 Canadian Journal of Analytical Sciences and Spectroscopy;Can. J. Anal. Sci. Spectrosc.
 Canadian Journal of Biochemistry;Can. J. Biochem.
 Canadian Journal of Botany;Can. J. Bot.
-Canadian Journal of Botany;Can. J. Bot.
 Canadian Journal of Chemical Engineering;Can. J. Chem. Eng.
 Canadian Journal of Chemistry;Can. J. Chem.
-Canadian Journal of Earth Sciences;Can. J. Earth Sci.
+Canadian Journal of Diabetes;Can. J. Diabetes;;
 Canadian Journal of Earth Sciences;Can. J. Earth Sci.
 Canadian Journal of Fisheries and Aquatic Sciences;Can. J. Fish. Aquat. Sci.
 Canadian Journal of Forest Research;Can. J. For. Res.
@@ -737,11 +909,13 @@ Canadian Journal of Physiology and Pharmacology;Can. J. Physiol. Pharmacol.
 Canadian Journal of Plant Pathology;Can. J. Plant Pathol.
 Canadian Journal of Plant Science;Can. J. Plant Sci.
 Canadian Journal of Remote Sensing;Can. J. Remote Sens.
-Canadian Journal of Zoology;Can. J. Zool.
+Canadian Journal of Urban Research;Can. J. Urban Res.;;
 Canadian Journal of Zoology;Can. J. Zool.
 Canadian Metallurgical Quarterly;Can. Metall. Q.
 Canadian Mineralogist;Can. Mineral.
 Canadian Mining Journal;Can. Min. J.
+Canadian Society of Forensic Science Journal;Can. Soc. Forensic Sci. J.;;
+Canadian Young Scientist Journal;Can. Young Sci. J.;;
 Cancer Cell;Cancer Cell
 Cancer Gene Therapy;Cancer Gene Ther.
 Cancer Genomics & Proteomics;Cancer Genomics Proteomics
@@ -759,32 +933,40 @@ Carbon Balance and Management;Carbon Balance Manage.
 Carcinogenesis;Carcinogenesis
 Cardiovascular & Hematological Agents;Cardiovasc. Hematol. Agents
 Cardiovascular & Hematological Disorders: Drug Targets;Cardiovasc. Hematol. Disord.: Drug Targets
+Cardiovascular Pathology;Cardiovasc. Pathol.;;
 Cardiovascular Research;Cardiovasc. Res.
+Case Studies in Construction Materials;Case Stud. Constr. Mater.;;
+Case Studies in Engineering Failure Analysis;Case Stud. Eng. Fail. Anal.;;
+Case Studies in Nondestructive Testing and Evaluation;Case Stud. Nondestr.Test. Eval.;;
+Case Studies in Structural Engineering;Case Stud. Struct. Eng.;;
+Case Studies in Transport Policy;Case Stud. Transp. Policy;;
 Catalysis Communications;Catal. Commun.
 Catalysis Letters;Catal. Lett.
 Catalysis Reviews - Science and Engineering;Catal. Rev. - Sci. Eng.
 Catalysis Today;Catal. Today
+Catalysis, Structure & Reactivity;Catal. Struct. React.;;
 Cell (Cambridge, MA, United States);Cell (Cambridge, MA, U. S.)
-Cell and Tissue Research;Cell Tissue Res.
 Cell Biochemistry and Biophysics;Cell Biochem. Biophys.
 Cell Biochemistry and Function;Cell Biochem. Funct.
 Cell Biology International Reports;Cell Biol. Int. Rep.
 Cell Calcium;Cell Calcium
 Cell Cycle;Cell Cycle
+Cell Discovery;Cell Discovery;;
 Cell Growth & Differentiation;Cell Growth Differ.
 Cell Host & Microbe;Cell Host Microbe
 Cell Metabolism;Cell Metab.
 Cell Stem Cell;Cell Stem Cell
-Cellular and Molecular Biology (Paris, France, Online);Cell. Mol. Biol. (Paris, Fr., Online)
-Cellular and Molecular Biology (Paris, France, Print);Cell. Mol. Biol. (Paris, Fr., Print)
-Cellular and Molecular Biology (Sarreguemines, France, Online);Cell. Mol. Biol. (Sarreguemines, Fr., Online)
-Cellular and Molecular Biology (Sarreguemines, France, Print);Cell. Mol. Biol. (Sarreguemines, Fr., Print)
-Cellular and Molecular Biology;Cell. Mol. Biol.
-Cellular and Molecular Life Sciences;Cell. Mol. Life Sci.
+Cell and Tissue Research;Cell Tissue Res.
 Cellular Immunology;Cell. Immunol.
 Cellular Microbiology;Cell. Microbiol.
 Cellular Physiology and Biochemistry;Cell. Physiol. Biochem.
 Cellular Polymers;Cell. Polym.
+Cellular and Molecular Biology;Cell. Mol. Biol.
+Cellular and Molecular Biology (Paris, France, Online);Cell. Mol. Biol. (Paris, Fr., Online)
+Cellular and Molecular Biology (Paris, France, Print);Cell. Mol. Biol. (Paris, Fr., Print)
+Cellular and Molecular Biology (Sarreguemines, France, Online);Cell. Mol. Biol. (Sarreguemines, Fr., Online)
+Cellular and Molecular Biology (Sarreguemines, France, Print);Cell. Mol. Biol. (Sarreguemines, Fr., Print)
+Cellular and Molecular Life Sciences;Cell. Mol. Life Sci.
 Cellulose Chemistry and Technology;Cellul. Chem. Technol.
 Cement & Concrete Composites;Cem. Concr. Compos.
 Cement and Concrete Research;Cem. Concr. Res.
@@ -802,53 +984,57 @@ Ceska a Slovenska Farmacie;Ceska Slov. Farm.
 Ceskoslovenska Farmacie;Cesk. Farm.
 Ceylon Forester;Ceylon For.
 ChemBioChem;ChemBioChem
+ChemMedChem;ChemMedChem
+ChemPhysChem;ChemPhysChem
+ChemSA;ChemSA
+ChemTech;Chem. Tech.
 Chemia Analityczna (Warsaw, Poland);Chem. Anal. (Warsaw, Pol.)
 Chemical & Pharmaceutical Bulletin;Chem. Pharm. Bull.
-Chemical and Biochemical Engineering Quarterly;Chem. Biochem. Eng. Q.
-Chemical and Engineering News;Chem. Eng. News
-Chemical and Pharmaceutical Bulletin;Chem. Pharm. Bull.
-Chemical and Physical Processes in Combustion;Chem. Phys. Processes Combust.
 Chemical Biology & Drug Design;Chem. Biol. Drug Des.
-Chemical Communications (Cambridge, United Kingdom);Chem. Commun. (Cambridge, U. K.)
 Chemical Communications;Chem. Commun.
+Chemical Communications (Cambridge, United Kingdom);Chem. Commun. (Cambridge, U. K.)
 Chemical Education Research and Practice;Chem. Educ. Res. Pract.
 Chemical Engineer (London);Chem. Eng. (London)
 Chemical Engineering & Technology;Chem. Eng. Technol.
 Chemical Engineering (New York);Chem. Eng. (N.Y.)
-Chemical Engineering and Processing;Chem. Eng. Process.
-Chemical Engineering and Technology;Chem. Eng. Technol.
 Chemical Engineering Communications;Chem. Eng. Commun.
+Chemical Engineering Journal;Chem. Eng. J.
 Chemical Engineering Journal (Amsterdam, Netherlands);Chem. Eng. J. (Amsterdam, Neth.)
 Chemical Engineering Journal (Lausanne);Chem. Eng. J. (Lausanne)
-Chemical Engineering Journal;Chem. Eng. J.
 Chemical Engineering Progress;Chem. Eng. Prog.
 Chemical Engineering Research and Design;Chem. Eng. Res. Des.
 Chemical Engineering Science;Chem. Eng. Sci.
+Chemical Engineering and Processing;Chem. Eng. Process.
+Chemical Engineering and Technology;Chem. Eng. Technol.
 Chemical Fibers International;Chem. Fibers Int.
 Chemical Geology;Chem. Geol.
-Chemical Papers - Chemicke Zvesti;Chem. Pap. - Chem. Zvesti
 Chemical Papers;Chem. Pap.
+Chemical Papers - Chemicke Zvesti;Chem. Pap. - Chem. Zvesti
 Chemical Physics;Chem. Phys.
 Chemical Physics Letters;Chem. Phys. Lett.
+Chemical Physics Research Journal;Chem. Phys. Res. J.;;
 Chemical Processing;Chem. Process.
 Chemical Record;Chem. Rec.
 Chemical Research in Chinese Universities;Chem. Res. Chin. Univ.
 Chemical Research in Toxicology;Chem. Res. Toxicol.
-Chemical Reviews (Washington, DC, United States);Chem. Rev. (Washington, DC, U. S.)
 Chemical Reviews;Chem. Rev.
+Chemical Reviews (Washington, DC, United States);Chem. Rev. (Washington, DC, U. S.)
 Chemical Senses;Chem. Senses
 Chemical Society Reviews;Chem. Soc. Rev.
 Chemical Speciation and Bioavailability;Chem. Speciation Bioavailability
 Chemical Vapor Deposition;Chem. Vap. Deposition
 Chemical Week;Chem. Week
+Chemical and Biochemical Engineering Quarterly;Chem. Biochem. Eng. Q.
+Chemical and Engineering News;Chem. Eng. News
+Chemical and Pharmaceutical Bulletin;Chem. Pharm. Bull.
+Chemical and Physical Processes in Combustion;Chem. Phys. Processes Combust.
 Chemicke Listy;Chem. Listy
 Chemicky Prumysl;Chem. Prum.
 Chemico-Biological Interactions;Chem.-Biol. Interact.
 Chemie Anlagen und Verfahren;Chem. -Anlagen Verfahren
+Chemie Ingenieur Technik;Chem. Ing. Tech.
 Chemie der Erde;Chem. Erde
 Chemie in unserer Zeit;Chem. unserer Zeit
-Chemie Ingenieur Technik;Chem. Ing. Tech.
-Chemie Ingenieur Technik;Chem. Ing. Tech.
 Chemie-Ingenieur-Technik;Chem.-Ing.-Tech.
 Chemija;Chemija
 Chemika Chronika;Chem. Chron.
@@ -857,40 +1043,36 @@ Chemine Technologija (Kaunas, Lithuania);Chem. Technol. (Kaunas, Lith.)
 Chemische Berichte;Chem. Ber.
 Chemische Berichte-Recueil;Chem. Ber. Recl.
 Chemische Industrie (Duesseldorf);Chem. Ind. (Duesseldorf)
-Chemische Technik (Leipzig);Chem. Tech. (Leipzig)
 Chemische Technik;Chem. Tech. (Leipzig)
+Chemische Technik (Leipzig);Chem. Tech. (Leipzig)
 Chemistry & Biodiversity;Chem. Biodiversity
-Chemistry & Biology (Cambridge, MA, United States);Chem. Biol. (Cambridge, MA, U. S.)
 Chemistry & Biology;Chem. Biol.
+Chemistry & Biology (Cambridge, MA, United States);Chem. Biol. (Cambridge, MA, U. S.)
 Chemistry & Industry (London, United Kingdom);Chem. Ind. (London, U. K.)
 Chemistry (Rajkot, India);Chemistry (Rajkot, India)
 Chemistry A European Journal;Chem. Eur. J.
 Chemistry An Asian Journal;Chem. Asian J.
+Chemistry Central Journal;Chem. Cent. J.
+Chemistry Express;Chem. Express
+Chemistry Letters;Chem. Lett.
 Chemistry and Biodiversity;Chem. Biodivers.
 Chemistry and Industry;Chem. Ind. (London)
 Chemistry and Physics of Carbon;Chem. Phys. Carbon
 Chemistry and Physics of Lipids;Chem. Phys. Lipids
 Chemistry and Technology of Fuels and Oils;Chem. Technol. Fuels Oils
-Chemistry Central Journal;Chem. Cent. J.
-Chemistry Express;Chem. Express
 Chemistry in Australia;Chem. Aust.
 Chemistry in Britain;Chem. Br.
 Chemistry in New Zealand;Chem. N.Z.
-Chemistry Letters;Chem. Lett.
-Chemistry of Heterocyclic Compounds (New York, NY, United States);Chem. Heterocycl. Compd. (N. Y., NY, U. S.)
 Chemistry of Heterocyclic Compounds;Chem. Heterocycl. Compd.
+Chemistry of Heterocyclic Compounds (New York, NY, United States);Chem. Heterocycl. Compd. (N. Y., NY, U. S.)
 Chemistry of Materials;Chem. Mater.
 Chemistry of Natural Compounds;Chem. Nat. Compd.
 Chemistry--A European Journal;Chem.--Eur. J.
 Chemistry--An Asian Journal;Chem.--Asian J.
-ChemMedChem;ChemMedChem
 Chemometrics and Intelligent Laboratory Systems;Chemom. Intell. Lab. Syst.
 Chemosphere;Chemosphere
 Chemotherapy (Basel, Switzerland);Chemotherapy (Basel, Switz.)
 Chemotherapy (Tokyo);Chemotherapy (Tokyo)
-ChemPhysChem;ChemPhysChem
-ChemSA;ChemSA
-ChemTech;Chem. Tech.
 Chemtracts;Chemtracts
 Chemtracts: Inorganic Chemistry;Chemtracts: Inorg. Chem.
 Chemtracts: Macromolecular Chemistry;Chemtracts: Macromol. Chem.
@@ -899,14 +1081,15 @@ Chimia;Chimia
 Chimica Acta Turcica;Chim. Acta Turc.
 Chimica e l'Industria (Milan, Italy);Chim. Ind. (Milan, Italy)
 Chimie Actualites;Chim. Actual.
-Chimie et Industrie, Genie Chimique;Chim. Ind. Genie Chim.
 Chimie Nouvelle;Chim. Nouv.
+Chimie et Industrie, Genie Chimique;Chim. Ind. Genie Chim.
 Chinese Chemical Letters;Chin. Chem. Lett.
 Chinese Journal of Astronomy and Astrophysics;Chin. J. Astron. Astrophys.
 Chinese Journal of Chemical Engineering;Chin. J. Chem. Eng.
 Chinese Journal of Chemical Physics;Chin. J. Chem. Phys.
 Chinese Journal of Chemistry;Chin. J. Chem.
 Chinese Journal of Geochemistry;Chin. J. Geochem.
+Chinese Journal of Geophysics;Chin. J. Geophys.;;
 Chinese Journal of Metal Science & Technology;Chin. J. Met. Sci. Technol.
 Chinese Journal of Nuclear Physics;Chin. J. Nucl. Phys.
 Chinese Journal of Polymer Science;Chin. J. Polym. Sci.
@@ -918,7 +1101,7 @@ Chirality;Chirality
 Chromatographia;Chromatographia
 Chromatographic Science Series;Chromatogr. Sci. Ser.
 Chromosome Research;Chromosome Res.
-CIM Bulletin;CIM Bull.
+Chronicle of the New Researcher;Chron. New Res.;;
 Circulation;Circulation
 Circulation Research;Circ. Res.
 Classical and Quantum Gravity;Classical Quantum Gravity
@@ -927,31 +1110,43 @@ Clays and Clay Minerals;Clays Clay Miner.
 Clean: Soil, Air, Water;Clean: Soil, Air, Water
 Climate Dynamics;Clim. Dyn.
 Climate Research;Clim. Res.
+Climate Risk Management;Clim. Risk Manage.;;
+Climate of the Past;Clim. Past;;
+Climate of the Past Discussion;Clim. Past Discuss.;;
 Climatic Change;Clim. Chang.
 Clinica Chimica Acta;Clin. Chim. Acta
-Clinical and Diagnostic Laboratory Immunology;Clin. Diagn. Lab. Immunol.
-Clinical and Experimental Immunology;Clin. Exp. Immunol.
-Clinical and Experimental Pharmacology and Physiology;Clin. Exp. Pharmacol. Physiol.
-Clinical and Vaccine Immunology;Clin. Vaccine Immunol.
 Clinical Biochemistry;Clin. Biochem.
-Clinical Chemistry (Washington, DC, United States);Clin. Chem. (Washington, DC, U. S.)
 Clinical Chemistry;Clin. Chem.
+Clinical Chemistry (Washington, DC, United States);Clin. Chem. (Washington, DC, U. S.)
 Clinical Chemistry and Laboratory Medicine;Clin. Chem. Lab. Med.
+Clinical Drug Investigation;Clin. Drug Invest.;;
 Clinical Immunology (San Diego, CA, United States);Clin. Immunol. (San Diego, CA, U. S.)
 Clinical Immunology and Immunopathology;Clin. Immunol. Immunopathol.
 Clinical Pharmacology and Therapeutics (St. Louis);Clin. Pharmacol. Ther. (St. Louis)
+Clinical Pharmacology in Drug Development;Clin. Pharmacol. Drug Dev.;;
 Clinical Physics and Physiological Measurement;Clin. Phys. Physiol. Meas.
+Clinical Phytoscience;Clin. Phytosci.;;
 Clinical Proteomics;Clin. Proteomics
+Clinical Psychopharmacology and Neuroscience;Clin. Psychopharmacol. Neurosci.;;
 Clinical Science;Clin. Sci.
+Clinical and Diagnostic Laboratory Immunology;Clin. Diagn. Lab. Immunol.
+Clinical and Experimental Immunology;Clin. Exp. Immunol.
+Clinical and Experimental Pharmacology and Physiology;Clin. Exp. Pharmacol. Physiol.
+Clinical and Translational Science;Clin. Transl. Sci.;;
+Clinical and Vaccine Immunology;Clin. Vaccine Immunol.
+Cllinical and Experimental Dental Research;Clin. Exp. Dent. Res.;;
 Cloning and Stem Cells;Cloning Stem Cells
-CNS & Neurological Disorders: Drug Targets;CNS Neurol. Disord.: Drug Targets
 Coal Preparation (Philadelphia, PA, United States);Coal Prep. (Philadelphia, PA, U. S.)
 Coenoses;Coenoses
+Cognitive Systems Research;Cognit. Syst. Res.;;
 Cold Regions Science and Technology;Cold Reg. Sci. Technol.
+Cold Spring Harbor Perspectives in Biology;Cold Spring Harbor Perspect. Biol.;;
 Cold Spring Harbor Symposia on Quantitative Biology;Cold Spring Harbor Symp. Quant. Biol.
 Collection of Czechoslovak Chemical Communications;Collect. Czech. Chem. Commun.
-Colloid and Polymer Science;Colloid Polym. Sci.
 Colloid Journal;Colloid J.
+Colloid and Interface Science Communications;Colloid Interface Sci. Commun.;;
+Colloid and Polymer Science;Colloid Polym. Sci.
+Colloids and Interface Science Communications;Colloids Interface Sci. Commun.;;
 Colloids and Surfaces;Colloids Surf.
 Colloids and Surfaces, A: Physicochemical and Engineering Aspects;Colloids Surf., A
 Colloids and Surfaces, B: Biointerfaces;Colloids Surf., B
@@ -960,17 +1155,17 @@ Colonial Plant and Animal Products;Colon. Plant Anim. Prod.
 Colonial Waterbirds;Colon. Waterbirds
 Coloration Technology;Color. Technol.
 Combinatorial Chemistry & High Throughput Screening;Comb. Chem. High Throughput Screening
-Combustion and Flame;Combust. Flame
 Combustion Science and Technology;Combust. Sci. Technol.
 Combustion Theory and Modelling;Combust. Theor. Model.
+Combustion and Flame;Combust. Flame
 Comments on Inorganic Chemistry;Comments Inorg. Chem.
 Commonwealth Forestry Review, The;Commonw. For. Rev.
 Communicationes Instituti Forestalis Fenniae;Commun. Inst. For. Fenn.
+Communications Surveys and Tutorials;Commun. Surveys Tuts.
 Communications in Soil Science and Plant Analysis;Commun. Soil Sci. Plant Anal.
 Communications in Theoretical Physics;Commun. Theor. Phys.
-Communications Surveys and Tutorials;Commun. Surveys Tuts.
+Communicative & Integrative Biology;Commun. Integr. Biol.;;
 Community Ecology;Community Ecol.
-Comparative and Functional Genomics;Comp. Funct. Genomics
 Comparative Biochemistry and Physiology, A: Comparative Physiology;Comp. Biochem. Physiol., A: Comp. Physiol.
 Comparative Biochemistry and Physiology, B: Comparative Biochemistry;Comp. Biochem. Physiol., B: Comp. Biochem.
 Comparative Biochemistry and Physiology, C: Comparative Pharmacology and Toxicology;Comp. Biochem. Physiol., C: Comp. Pharmacol. Toxicol.
@@ -979,6 +1174,7 @@ Comparative Biochemistry and Physiology, Part B: Biochemistry & Molecular Biolog
 Comparative Biochemistry and Physiology, Part C: Toxicology & Pharmacology;Comp. Biochem. Physiol., Part C: Toxicol. Pharmacol.
 Comparative Biochemistry and Physiology, Part D: Genomics & Proteomics;Comp. Biochem. Physiol., Part D: Genomics Proteomics
 Comparative Medicine;Comp. Med.
+Comparative and Functional Genomics;Comp. Funct. Genomics
 Complexity International;Complexity Int.
 Composite Interfaces;Compos. Interfaces
 Composite Structures;Compos. Struct.
@@ -986,30 +1182,38 @@ Composites Engineering;Compos. Eng.
 Composites Part A Applied Science and Manufacturing;Composites Part A
 Composites Part B Engineering;Composites Part B
 Composites Science and Technology;Compos. Sci. Technol.
+Comprehensive Reviews in Food Science and Food Safety;Compr. Rev. Food Sci. Food Saf.;;
 Comptes Rendus Biologies;C. R. Biol.
 Comptes Rendus Chimie;C. R. Chim.
-Comptes Rendus de l' Academie des Sciences Serie IIc: Chemie;C. R. Acad. Sci., Ser. IIc: Chim.
-Comptes Rendus de l' Academie des Sciences Serie III: Sciences de la Vie;C. R. Acad. Sci., Ser. III
-Comptes Rendus de l'Academie des Sciences, Serie IIa: Sciences de la Terre et des Planets;C. R. Acad. Sci., Ser. IIa: Sci. Terre Planets
-Comptes Rendus de l'Academie des Sciences, Serie IIb: Mecanique Physique Chimie Astronomie;C. R. Acad. Sci., Ser. IIb: Mec., Phys., Chim., Astron.
-Comptes rendus des séances de l'Académie d'Agriculture de France;Comptes rendus séance Acad. Agric. Fr.
 Comptes Rendus Geoscience;C. R. Geosci.
-Comptes rendus hebdomadaires des séances de l'académie des sciences, Paris;Comptes rendus hebd. séances acad. sci. Paris
 Comptes Rendus Mathematique;C .R. Math.
 Comptes Rendus Mecanique;C .R. Mec.
 Comptes Rendus Palevol;C. R. Palevol
 Comptes Rendus Physique;C. R. Phys.
+Comptes Rendus de l' Academie des Sciences Serie III: Sciences de la Vie;C. R. Acad. Sci., Ser. III
+Comptes Rendus de l' Academie des Sciences Serie IIc: Chemie;C. R. Acad. Sci., Ser. IIc: Chim.
+Comptes Rendus de l'Academie des Sciences, Serie IIa: Sciences de la Terre et des Planets;C. R. Acad. Sci., Ser. IIa: Sci. Terre Planets
+Comptes Rendus de l'Academie des Sciences, Serie IIb: Mecanique Physique Chimie Astronomie;C. R. Acad. Sci., Ser. IIb: Mec., Phys., Chim., Astron.
+Comptes rendus des séances de l'Académie d'Agriculture de France;Comptes rendus séance Acad. Agric. Fr.
+Comptes rendus hebdomadaires des séances de l'académie des sciences, Paris;Comptes rendus hebd. séances acad. sci. Paris
 Computation Materials Science;Comput. Mater. Sci.
-Computational and Theoretical Polymer Science;Comput. Theor. Polym. Sci.
 Computational Biology and Chemistry;Comput. Biol. Chem.
+Computational Condensed Matter;Comput. Condens. Matter;;
+Computational Geometry: Theory and Applications;Comput. Geom. Theory Appl.;;
 Computational Science & Discovery;Comput. Sci. Discovery
 Computational Statistics and Data Analysis;Comput. Stat. Data Anal.
+Computational and Structural Biotechnology Journal;Comput. Struct. Biotechnol. J.;;
+Computational and Theoretical Chemistry;Comput. Theor. Chem.;;
+Computational and Theoretical Polymer Science;Comput. Theor. Polym. Sci.
 Computer Applications in the Biosciences;Comput. Appl. Biosci.
+Computer Music Journal;Comput. Music J.;;
+Computer Networks;Comput. Networks;;
 Computer Physics Communications;Comput. Phys. Commun.
 Computers & Chemical Engineering;Comput. Chem. Eng.
 Computers and Chemistry;Comput. Chem. (Oxford)
 Computers and Electronics in Agriculture;Comput. Electron. Agric.
 Computers and Geosciences;Comput. Geosci.
+Computers, Environment and Urban Systems;Comput. Environ. Urban Syst.;;
 Computing Letters;Comput. Lett.
 Comunicaciones presentadas a las Jornadas del Comite Espanol de la Detergencia;Comun. Jorn. Com. Esp. Deterg.
 Concepts in Magenetic Resonance;Concepts Magn. Reson.
@@ -1022,12 +1226,12 @@ Condor, The;Condor
 Conference Record of the IEEE Photovoltaic Specialists Conference;Conf. Rec. IEEE Photovoltaic Spec. Conf.
 Conservation Biology;Conserv. Biol.
 Contemporary Topics in Laboratory Animal Science;Contemp. Top. Lab. Anim. Sci.
-Continuum Mechanics and Thermodynamics;Contin. Mech. Thermodyn.
 Continuum Mechanics and Thermodynamics;Continuum Mech. Thermodyn.
 Contrast Media & Molecular Imaging;Contrast Media Mol. Imaging
 Contributions from the Central Research Institute for Agriculture Bogor;Contrib. Cent. Res. Inst. Agric. Bogor
 Contributions from the United States National Herbarium;Contrib. U. S. Natl. Herb.
 Contributions to Mineralogy and Petrology;Contrib. Mineral. Petrol.
+Control & Automation;Control Autom.;;
 Coordination Chemistry Reviews;Coord. Chem. Rev.
 Cornell Plantations;Cornell Plant.
 Corrosion (Houston, TX, United States);Corrosion (Houston, TX, U. S.)
@@ -1036,7 +1240,6 @@ Corrosion Reviews;Corros. Rev.
 Corrosion Science;Corros. Sci.
 Courrier de l’environnement de l’INRA, Le;Courr. environ. INRA
 Courrier de l’exploitant et du scieur;Courr. exploit. scieur
-CPP Chemical Plants and Processing;CPP Chem. Plants and Process.
 Critical Reviews in Analytical Chemistry;Crit. Rev. Anal. Chem.
 Critical Reviews in Biochemistry and Molecular Biology;Crit. Rev. Biochem. Mol. Biol.
 Critical Reviews in Biotechnology;Crit. Rev. Biotechnol.
@@ -1045,13 +1248,14 @@ Critical Reviews in Solid State and Materials Sciences;Crit. Rev. Solid State Ma
 Critical Reviews in Toxicology;Crit. Rev. Toxicol.
 Croatica Chemica Acta;Croat. Chem. Acta
 Cryogenics;Cryogenics
+Cryosphere Discussions;Cryosphere Discuss.;;
 Cryptogamic Botany;Cryptogam. Bot.
+CrystEngComm;CrystEngComm
 Crystal Engineering;Cryst. Eng.
 Crystal Growth & Design;Cryst. Growth Des.
 Crystal Research and Technology;Cryst. Res. Technol.
 Crystallography;Acta Crystallogr., Sect. A: Found. Crystallogr.
 Crystallography Reports;Crystallogr. Rep.
-CrystEngComm;CrystEngComm
 Cuihua Xuebao;Cuihua Xuebao
 Current Alzheimer Research;Curr. Alzheimer Res.
 Current Analytical Chemistry;Curr. Anal. Chem.
@@ -1061,12 +1265,13 @@ Current Biology;Curr. Biol.
 Current Cancer Drug Targets;Curr. Cancer Drug Targets
 Current Chemical Biology;Curr. Chem. Biol.
 Current Computer-Aided Drug Design;Curr. Comput.-Aided Drug Des.
+Current Drug Abuse Reviews;Curr. Drug Abuse Rev.;;
 Current Drug Delivery;Curr. Drug Delivery
 Current Drug Discovery Technologies;Curr. Drug Discovery Technol.
 Current Drug Metabolism;Curr. Drug Metab.
 Current Drug Targets;Curr. Drug Targets
-Current Drug Targets: Cardiovascular & Haematological Disorders;Curr. Drug Targets: Cardiovasc. & Haematol. Disord.
 Current Drug Targets: CNS & Neurological Disorders;Curr. Drug Targets: CNS Neurol. Disord.
+Current Drug Targets: Cardiovascular & Haematological Disorders;Curr. Drug Targets: Cardiovasc. & Haematol. Disord.
 Current Drug Targets: Immune, Endocrine and Metabolic Disorders;Curr. Drug Targets: Immune, Endocr. Metab. Disord.
 Current Drug Targets: Infectious Disorders;Curr. Drug Targets: Infect. Disord.
 Current Drug Targets: Inflammation & Allergy;Curr. Drug Targets: Inflammation Allergy
@@ -1091,8 +1296,10 @@ Current Opinion in Cell Biology;Curr. Opin. Cell Biol.
 Current Opinion in Chemical Biology;Curr. Opin. Chem. Biol.
 Current Opinion in Colloid & Interface Science;Curr. Opin. Colloid Interface Sci.
 Current Opinion in Drug Discovery & Development;Curr. Opin. Drug Discovery Dev.
+Current Opinion in Food Science;Curr. Opin. Food Sci.;;
 Current Opinion in Genetics & Development;Curr. Opin. Genet. Dev.
 Current Opinion in Immunology;Curr. Opin. Immunol.
+Current Opinion in Insect Science;Curr. Opin. Insect Sci.;;
 Current Opinion in Lipidology;Curr. Opin. Lipidol.
 Current Opinion in Neurobiology;Curr. Opin. Neurobiol.
 Current Opinion in Pharmacology;Curr. Opin. Pharmacol.
@@ -1104,46 +1311,60 @@ Current Pharmaceutical Analysis;Curr. Pharm. Anal.
 Current Pharmaceutical Biotechnology;Curr. Pharm. Biotechnol.
 Current Pharmaceutical Design;Curr. Pharm. Des.
 Current Pharmacogenomics;Curr. Pharmacogenomics
+Current Plant Biology;Curr. Plant Biol.;;
 Current Plant Science in Biotechnology and Agriculture;Curr. Plant Sci. Biotechnol. Agric.
+Current Protein & Peptide Science;Curr. Protein Pept. Sci.;;
 Current Protein and Peptide Science;Curr. Protein Pept. Sci.
 Current Proteomics;Curr. Proteomics
-Current Science;Curr. Sci.
 Current Science;Curr. Sci.
 Current Separations;Curr. Sep.
 Current Separations and Drug Development;Curr. Sep Drug Dev.
 Current Signal Transduction Therapy;Curr. Signal Transduction Ther.
 Current Stem Cell Research & Therapy;Curr. Stem Cell Res. Ther.
 Current Topics in Cellular Regulation;Curr. Top. Cell. Regul.
-Current Topics in Medicinal Chemistry (Sharjah, United Arab Emirates);Curr. Top. Med. Chem. (Sharjah, United Arab Emirates)
 Current Topics in Medicinal Chemistry;Curr. Top. Med. Chem.
+Current Topics in Medicinal Chemistry (Sharjah, United Arab Emirates);Curr. Top. Med. Chem. (Sharjah, United Arab Emirates)
 Current Topics in Membranes;Curr. Top. Membr.
 Current Vascular Pharmacology;Curr. Vasc. Pharmacol.
 Cytokine & Growth Factor Reviews;Cytokine Growth Factor Rev.
 Cytokine (Philadelphia);Cytokine (Philadelphia)
 Cytokine+;Cytokine+
+Cytometry, Part B: Clinical Cytometry;Cytometry, Part B;;
 Czechoslovak Journal of Physics;Czech. J. Phys.
+DECHEMA Biotechnology Conferences;DECHEMA Biotechnol. Conf.
+DNA Repair;DNA Repair
+DNA Research;DNA Res.
+DNA Sequence;DNA Sequence
+DNA and Cell Biology;DNA Cell Biol.
+DVS Berichte;DVS Ber.
 Dalton Transactions;Dalton Trans.
 Dangerous Properties of Industrial Materials Report;Dangerous Prop. Ind. Mater. Rep.
+Data Science Journal;Data Sci. J.;;
+Data Science and Engineering;Data Sci. Eng.;;
+Data and Knowledge Engineering;Data Knowl. Eng.;;
 Davoser Revue;Davos. Rev.
 Daxue Huaxue;Daxue Huaxue
-DECHEMA Biotechnology Conferences;DECHEMA Biotechnol. Conf.
 Dendrochronologia;Dendrochronologia
 Dendronatura;Dendronatura
 Denki Kagaku oyobi Kogyo Butsuri Kagaku;Denki Kagaku oyobi Kogyo Butsuri Kagaku
 Denkschriften der Schweizerischen naturforschenden Gesellschaft;Denkschr. Schweiz. nat.forsch. Ges.
 Dental Materials;Dent. Mater.
+Depositional Record;Depositional Rec.;;
 Dermatologic Clinics;Dermatol. Clin.
 Dermatologic Surgery;Dermatol. Surg.
 Dermatology Times;Dermatol. Times
 Desalination;Desalination
+Design Issues;Des. Issues;;
 Designed Monomers and Polymers;Des. Monomers Polym.
 Deutsche Baumschule;Dtsch. Baumsch.
-Deutsche gewässerkundliche Mitteilungen;Dtsch. gewässerkdl. Mitt.
+Deutsche Entomologische Zeitschrift;Dtsch. Entomol. Z.;;
 Deutsche Hydrographische Zeitschrift;Dtsch. Hydrogr. Z.
 Deutsche Lebensmittel-Rundschau;Dtsch. Lebensm.-Rundsch.
+Deutsche gewässerkundliche Mitteilungen;Dtsch. gewässerkdl. Mitt.
 Development (Cambridge, United Kingdom);Development (Cambridge, U. K.)
-Developmental Biology (San Diego, CA, United States);Dev. Biol. (San Diego, CA, U. S.)
+Developmental & Comparative Immunology;Dev. Comp. Immunol.;;
 Developmental Biology;Dev. Biol.
+Developmental Biology (San Diego, CA, United States);Dev. Biol. (San Diego, CA, U. S.)
 Developmental Brain Research;Dev. Brain Res.
 Developmental Cell;Dev. Cell
 Developmental Neuroscience (Basel, Switzerland);Dev. Neurosci. (Basel, Switz.)
@@ -1153,21 +1374,21 @@ Developments in Industrial Microbiology;Dev. Ind. Microbiol.
 Developments in Plant and Soil Sciences;Dev. Plant Soil Sci.
 Diabetes;Diabetes
 Diabetologia;Diabetologia
-Diamond and Related Materials;Diamond Relat. Mater.
+Diagnostic Pathology;Diagn. Pathol.;;
+Diagnostic and Interventional Imaging;Diagn. Interventional Imaging;;
 Diamond Films and Technology;Diamond Films Technol.
+Diamond and Related Materials;Diamond Relat. Mater.
 Dianhuaxue;Dianhuaxue
 Differentiation (Malden, MA, United States);Differentiation (Malden, MA, U. S.)
 Diffusion and Defect Data--Solid State Data, Pt. A: Defect and Diffusion Forum;Diffus. Defect Data, Pt. A
 Diffusion and Defect Data--Solid State Data, Pt. B: Solid State Phenomena;Diffus. Defect Data, Pt. B
 Digestive Diseases and Sciences;Dig. Dis. Sci.
+Digital Investigation;Digital Invest.;;
 Diqiu Huaxue;Diqiu Huaxue
 Dissertationes Botanicae;Diss. Bot.
 Distributed Systems Engineering;Distrib. Sys. Eng.
 Diversity;Diversity
-DNA and Cell Biology;DNA Cell Biol.
-DNA Repair;DNA Repair
-DNA Research;DNA Res.
-DNA Sequence;DNA Sequence
+Diversity and Distributions;Divers. Distrib.;;
 Documenta Faunistica Helvetiae;Doc. Faun. Helv.
 Documents Mycologiques;Doc. Mycol.
 Documents phytosociologiques, nouvelle série;Doc. phytosociol., nouv. sér.
@@ -1186,76 +1407,121 @@ Doklady Physics;Dokl. Phys.
 Dokument Bodenkundliche Gesellschaft der Schweiz;Dok. Bodenkd. Ges. Schweiz
 Dokumente und Informationen zur schweizerischen Orts-, Regional- und Landesplanung, DISP;Dok. Inf. schweiz. Orts- Reg.- Landesplan., DISP
 Dopovidi Natsional'noi Akademii Nauk Ukraini;Dopov. Nats. Akad. Nauk Ukr.
-Drug and Chemical Toxicology (1977);Drug Chem. Toxicol. (1977)
+Drinking Water Engineering and Science;Drinking Water Eng. Sci.;;
+Drinking Water Engineering and Science Discussions;Drinking Water Eng. Sci. Discuss.;;
 Drug Delivery;Drug Delivery
 Drug Design and Discovery;Drug Des. Discovery
-Drug Development and Industrial Pharmacy;Drug Dev. Ind. Pharm.
 Drug Development Research;Drug Dev. Res.
+Drug Development and Industrial Pharmacy;Drug Dev. Ind. Pharm.
 Drug Discovery and Development;Drug Discovery Dev.
+Drug Metabolism Letters;Drug Metab. Lett.
 Drug Metabolism and Disposition;Drug Metab. Dispos.
 Drug Metabolism and Drug Interactions;Drug Metab. Drug Interact.
 Drug Metabolism and Pharmacokinetics;Drug Metab. Pharmacokinet.
-Drug Metabolism Letters;Drug Metab. Lett.
+Drug Repurposing, Rescue, and Repositioning;Drug Repurposing Rescue Repositioning;;
+Drug and Chemical Toxicology (1977);Drug Chem. Toxicol. (1977)
 Drugs under Experimental and Clinical Research;Drugs Exp. Clin. Res.
 Drying Technology;Drying Technol.
-DVS Berichte;DVS Ber.
 Dyes and Pigments;Dyes Pigm.
-Earth and Planetary Science Letters;Earth Planet. Sci. Lett.
+ECS Transactions;ECS Trans.
+EFSA Journal;EFSA J.;;
+EMBO Journal;EMBO J.
+EMBO Reports;EMBO Rep.
+EOS, Transactions, American Geophysical Union;EOS Trans. Trans. Am. Geophys. Union
+EPL;EPL
+ESIS Publication;ESIS Publ.
+ETFRN (European Tropical Forest Research Network) Newsletter;ETFRN Newsletter
+EURASIP Journal on Bioinformatics & Systems Biology;EURASIP J. Bioinf. Syst. Biol.
+Earth Surface Dynamics;Earth Surf. Dyn.;;
+Earth Surface Dynamics Discussions;Earth Surf. Dyn. Discuss.;;
 Earth Surface Processes and Landforms;Earth Surf. Process. Landf.
+Earth System Dynamics;Earth Syst. Dyn.;;
+Earth System Dynamics Discussions;Earth Syst. Dyn. Discuss.;;
+Earth System Science Data;Earth Syst. Sci. Data;;
+Earth System Science Data Discussions;Earth Syst. Sci. Data Discuss.;;
+Earth and Planetary Science Letters;Earth Planet. Sci. Lett.
+Earth and Space Science;Earth Space Sci.;;
+Earth's Future;Earth's Future;;
+Earth, Planets and Space;Earth Planets Space;;
+Echo Research and Practice;Echo Res. Pract.;;
 Eclogae Geologicae Helvetiae;Eclogae Geol. Helv.
 Ecography;Ecography
 Ecologia Mediterranea;Ecol. Mediterr.
 Ecological Applications;Ecol. Appl.
 Ecological Chemistry and Engineering;Ecol. Chem. Eng.
+Ecological Complexity;Ecol. Complexity;;
 Ecological Economics;Ecol. Econ.
 Ecological Engineering;Ecol. Eng.
-Ecological Engineering;Ecol. Eng.
 Ecological Entomology;Ecol. Entomol.
-Ecological Modelling;Ecol. Model.
+Ecological Informatics;Ecol. Inf.;;
 Ecological Modelling;Ecol. Model.
 Ecological Monographs;Ecol. Monogr.
 Ecological Research;Ecol. Res.
 Ecological Studies;Ecol. Stud.
 Ecology;Ecology
+Ecology and Society;Ecol. Soc.;;
 Economic Botany;Econ. Bot.
 Economic Geology;Econ. Geol.
 Economic Geology and the Bulletin of the Society of Economic Geologists;Econ. Geol.
+Ecosystem Health and Sustainability;Ecosyst. Health Sustainability;;
+Ecosystem Services;Ecosyst. Serv.;;
 Ecotoxicology and Environmental Safety;Ecotoxicol. Environ. Saf.
-ECS Transactions;ECS Trans.
 Education in Chemistry;Educ. Chem.
+Egyptian Journal of Agronomy;Egypt. J. Agron.;;
+Egyptian Journal of Analytical Chemistry;Egypt. J. Anal. Chem.;;
+Egyptian Journal of Aquatic Research;Egypt. J. Aquat. Res.;;
+Egyptian Journal of Biochemistry and Molecular Biology;Egypt. J. Biochem. Mol. Biol.;;
+Egyptian Journal of Biotechnology;Egypt. J. Biotechnol.;;
 Egyptian Journal of Chemistry;Egypt. J. Chem.
+Egyptian Journal of Geology;Egypt. J. Geol.;;
+Egyptian Journal of Hospital Medicine;Egypt. J. Hosp. Med.;;
+Egyptian Journal of Petroleum;Egypt. J. Pet.;;
+Egyptian Journal of Radiology and Nuclear Medicine;Egypt. J. Radiol. Nucl. Med.;;
+Egyptian Journal of Remote Sensing and Space Science;Egypt. J. Remote Sens. Space. Sci.;;
 Eiszeitalter und Gegenwart;Eiszeitalt. Ggw.
 Ekologia (CSSR);Ekologia (CSSR)
 Ekotekhnologii i Resursosberezhenie;Ekotekhnol. Resursosberezhenie
 Eksperimental'naya i Klinicheskaya Farmakologiya;Eksp. Klin. Farmakol.
+Electric Power Systems Research;Electr. Power Syst. Res.;;
 Electro- and Magnetobiology;Electro- Magnetobiol.
-Electroanalysis (New York);Electroanalysis
 Electroanalysis;Electroanalysis
+Electroanalysis (New York);Electroanalysis
 Electroanalytical Chemistry;Electroanal. Chem.
-Electrochemical and Solid-State Letters;Electrochem. Solid-State Lett.
 Electrochemical Society Interface;Electrochem. Soc. Interface
+Electrochemical and Solid-State Letters;Electrochem. Solid-State Lett.
 Electrochemistry (Tokyo, Japan);Electrochemistry (Tokyo, Jpn.)
 Electrochemistry Communications;Electrochem. Commun.
 Electrochimica Acta;Electrochim. Acta
 Electron Microscopy;Electron Microsc.
+Electronic Journal of Operational Meteorology;Electron. J. Oper. Meteorol.;;
+Electronic Journal of Severe Storms Metereology;Electron. J. Severe Storms Metereol.;;
 Electronic Materials Letters;Electron. Mater. Lett.
+Electronic Systems News;Electron. Syst. News;;
 Electronic Technology;Electron Technol.
+Electronics Education;Electron. Educ.;;
 Electronics Letters;Electron. Lett
-Electrophoresis (Weinheim, Federal Republic of Germany);Electrophoresis (Weinheim, Fed. Repub. Ger.)
+Electronics and Power;Electron. Power;;
 Electrophoresis;Electrophoresis
+Electrophoresis (Weinheim, Federal Republic of Germany);Electrophoresis (Weinheim, Fed. Repub. Ger.)
 Elektrokhimiya;Elektrokhimiya
-EMBO Journal;EMBO J.
-EMBO Reports;EMBO Rep.
 Endeavour;Endeavour
 Endocrine;Endocrine
 Endocrine, Metabolic & Immune Disorders: Drug Targets;Endocr., Metab. Immune Disord.: Drug Targets
-Endocrinology (Baltimore);Endocrinology (Baltimore)
 Endocrinology;Endocrinology
+Endocrinology (Baltimore);Endocrinology (Baltimore)
 Enegie Wasser Praxis;Energ. Wasser Prax.
 Energy & Fuels;Energy Fuels
-Energy and Buildings;Energy Build.
 Energy Conversion and Management;Energy Convers. Manage.
+Energy Economics;Energy Econ.;;
+Energy Harvesting Systems;Energy Harvesting Syst.;;
+Energy Research & Social Science;Energy Res. Social Sci.;;
+Energy and Buildings;Energy Build.
+Engineering & Technology;Eng. Technol.;;
+Engineering Management Journal;Eng. Manage. J.;;
+Engineering Science and Education Journal;Eng. Sci. Educ. J.;;
+Engineering Science and Technology;Eng. Sci. Technol.;;
 Engineering and Mining Journal;Eng. Min. J.
+Engineering in Agriculture, Environment and Food;Eng. Agric. Environ. Food;;
 Engineering in Life Sciences;Eng. Life Sci.
 Ensho;Ensho
 Entomofauna;Entomofauna
@@ -1264,68 +1530,69 @@ Entomologische Berichte Luzern;Entomol. Ber. Luzern
 Entomologische Zeitschrift;Entomol. Z.
 Environ. Chem. Preprints of Extended Abstracts presented at the ACS National Meeting, American Chemical Society, Division of Environmental Chemistry;Prepr. Ext. Abstr. ACS Natl. Meet., Am. Chem. Soc., Div.
 Environ. Eng. Journal of Environmental Science and Health, Part A: Toxic/Hazardous Substances & Environmental Engineering;J. Environ. Sci. Health, Part A: Toxic/Hazard. Subst.
-Environment and History;Environ. Hist.
 Environment Carcinogenesis and Ecotoxicology Reviews;Environ. Carcinog. Ecotoxicol. Rev.
 Environment International;Environ. Int.
 Environment Protection Engineering;Environ. Prot. Eng.
-Environmental and Ecological Statistics;Environ. Ecol. Stat.
-Environmental and Experimental Botany;Environ. Exp. Bot.
-Environmental and Molecular Mutagenesis;Environ. Mol. Mutagen.
+Environment and History;Environ. Hist.
 Environmental Bioindicators;Environ. Bioindic.
 Environmental Biosafety Research;Environ. Biosaf. Res.
 Environmental Chemistry;Environ. Chem.
 Environmental Chemistry Letters;Environ. Chem. Lett.
 Environmental Conservation;Environ. Conserv.
+Environmental Engineering Research;Environ. Eng. Res.;;
 Environmental Engineering Science;Environ. Eng. Sci.
 Environmental Entomology;Environ. Entomol.
 Environmental Ethics;Environ. Ethics
 Environmental Geochemistry and Health;Environ. Geochem. Health
 Environmental Geology;Environ. Geol.
-Environmental Geology;Environ. Geol.
 Environmental Geology and Water Sciences;Environ. Geol. Water Sci.
 Environmental Health Perspectives;Environ. Health Perspect.
+Environmental Health and Preventive Medicine;Environ. Health Preventative Med.;;
 Environmental History Newsletter;Environ. Hist. Newsl.
 Environmental Microbiology;Environ. Microbiol.
 Environmental Monitoring and Assessment;Environ. Monit. Assess.
-Environmental Monitoring and Assessment;Environ. Monit. Assess.
+Environmental Nanotechnology, Monitoring & Management;Environ. Nanotechnol. Monit. Manage.;;
+Environmental Pollution;Environ. Pollut.
 Environmental Pollution (Amsterdam, Netherlands);Environ. Pollut. (Amsterdam, Neth.)
-Environmental Pollution;Environ. Pollut.
-Environmental Pollution;Environ. Pollut.
 Environmental Progress;Environ. Prog.
 Environmental Research;Environ. Res.
 Environmental Research Letters;Environ. Res. Lett.
 Environmental Review;Environ. Rev.
 Environmental Science & Technology;Environ. Sci. Technol.
 Environmental Science and Pollution Research;Environ. Sci. Pollut. Res.
+Environmental Science and Technology Letters;Environ. Sci. Technol. Lett.;;
+Environmental Science: Water Research & Technology;Environ. Sci. Water Res. Technol.;;
+Environmental Sciences Europe;Environ. Sci. Eur.;;
 Environmental Technology;Environ. Technol.
+Environmental Technology & Innovation;Environ. Technol. Innovation;;
 Environmental Toxicology;Environ. Toxicol.
 Environmental Toxicology and Chemistry;Environ. Toxicol. Chem.
 Environmental Toxicology and Pharmacology;Environ. Toxicol. Pharmacol.
 Environmental Toxicology and Water Quality;Environ. Toxicol. Water Qual.
 Environmental Values;Environ. Values
+Environmental and Ecological Statistics;Environ. Ecol. Stat.
+Environmental and Experimental Botany;Environ. Exp. Bot.
+Environmental and Molecular Mutagenesis;Environ. Mol. Mutagen.
+Environmental and Resource Economics;Environ. Resour. Econ.;;
 Enzyme and Microbial Technology;Enzyme Microb. Technol.
 Enzyme and Protein;Enzyme Protein
-EOS, Transactions, American Geophysical Union;EOS Trans. Trans. Am. Geophys. Union
-EPL;EPL
 Erdoel & Kohle Erdgas, Petrochemie;Erdoel, Kohle, Erdgas, Petrochem.
 Erdoel, Erdgas, Kohle;Erdoel, Erdgas, Kohle
 Ergebnisse der wissenschaftlichen Untersuchungen im schweizerischen Nationalpark;Ergeb. wiss. Unters. schweiz. Natl.park
 Es + T;Es +T
-ESIS Publication;ESIS Publ.
 Esperienze e ricerche;Esper. ric.
 Essays in Biochemistry;Essays Biochem.
-ETFRN (European Tropical Forest Research Network) Newsletter;ETFRN Newsletter
 Ettore Majorana International Science Series: Physical Sciences;Ettore Majorana Int. Sci. Ser.: Phys. Sci.
 Etude et Gestion des Sols;Etud. Gest. Sols
 Eukaryotic Cell;Eukaryotic Cell
 Eurasian Journal of Analytical Chemistry;Eurasian J. Anal. Chem.
 Eurasian Soil Science;Eurasian Soil Sci.
-EURASIP Journal on Bioinformatics & Systems Biology;EURASIP J. Bioinf. Syst. Biol.
 European Cytokine Network;Eur. Cytokine Network
 European Food Research and Technology;Eur. Food Res. Technol.
 European Journal of Biochemistry;Eur. J. Biochem.
 European Journal of Cell Biology;Eur. J. Cell Biol.
 European Journal of Clinical Chemistry and Clinical Biochemistry;Eur. J. Clin. Chem. Clin. Biochem.
+European Journal of Clinical Microbiology & Infectious Diseases;Eur. J. Clin. Microbiol. Infect. Dis.;;
 European Journal of Clinical Pharmacology;Eur. J. Clin. Pharmacol.
 European Journal of Drug Metabolism and Pharmacokinetics;Eur. J. Drug Metab. Pharmacokinet.
 European Journal of Endocrinology;Eur. J. Endocrinol.
@@ -1344,25 +1611,26 @@ European Journal of Pharmacology, Molecular Pharmacology Section;Eur. J. Pharmac
 European Journal of Physics;Eur. J. Phys.
 European Journal of Soil Science;Eur. J. Soil Sci.
 European Journal of Solid State and Inorganic Chemistry;Eur. J. Solid State Inorg. Chem.
-European Physical Journal Special Topics;Eur. Phys. J. Spec. Top.
 European Mass Spectrometry;Eur. Mass Spectrom.
 European Molecular Biology Organization Journal;Eur. Mol. Biol. Organ. J.
 European Neuropsychopharmacology;Eur. Neuropsychopharmacol.
 European Physical Journal A: Hadrons and Nuclei;Eur. Phys. J. A
+European Physical Journal B: Condensed Matter Physics;Eur. Phys. J. B;;
 European Physical Journal B: Condensed Matter and Complex Systems;Eur. Phys. J. B
 European Physical Journal C: Particles and Fields;Eur. Phys. J. C
+European Physical Journal D;Eur. Phys. J. D;;
+European Physical Journal D: Atomic, Molecular and Optical Physics;Eur. Phys. J. D;;
 European Physical Journal D: Atomic, Molecular, Optical and Plasma Physics;Eur. Phys. J. D
 European Physical Journal E: Soft Matter;Eur. Phys. J. E
+European Physical Journal Special Topics;Eur. Phys. J. Spec. Top.
 European Polymer Journal;Eur. Polym. J.
+European Urban and Regional Studies;Eur. Urban Reg. Stud.;;
 Europhysics Letters;Europhys. Lett.
 Europhysics News;Europhys. News
+Evolutionary Applications;Evol. Appl.;;
 Evolutionary Biology;Evol. Biol.
 Evolutionary Ecology;Evol. Ecol.
 Experientia;Experientia
-Experimental and Applied Acarology;Exp. Appl. Acarol.
-Experimental and Clinical Endocrinology & Diabetes;Exp. Clin. Endocrinol. Diabetes
-Experimental and Molecular Medicine;Exp. Mol. Med.
-Experimental and Molecular Pathology;Exp. Mol. Pathol.
 Experimental Animals;Exp. Anim.
 Experimental Biology and Medicine (Maywood, NJ, United States);Exp. Biol. Med. (Maywood, NJ, U. S.)
 Experimental Botany;Exp. Bot.
@@ -1373,31 +1641,42 @@ Experimental Hematology;Exp. Hematol.
 Experimental Mycology;Exp. Mycol.
 Experimental Neurology;Exp. Neurol.
 Experimental Thermal and Fluid Science;Exp. Therm Fluid Sci.
+Experimental and Applied Acarology;Exp. Appl. Acarol.
+Experimental and Clinical Endocrinology & Diabetes;Exp. Clin. Endocrinol. Diabetes
+Experimental and Molecular Medicine;Exp. Mol. Med.
+Experimental and Molecular Pathology;Exp. Mol. Pathol.
+Experimentelle Strahlentherapie und Klinische Strahlenbiologie;Exp. Strahlenther. Klin. Strahlenbiol.;;
 Experiments in Fluids;Exp. Fluids
 Expert Opinion on Drug Discovery;Expert Opin. Drug Discovery
 Expert Opinion on Drug Metabolsim & Toxicology;Expert Opin. Drug Metabol. Toxicol.
 Expert Opinion on Investigational Drugs;Expert Opin. Invest. Drugs
+Expert Opinion on Orphan Drugs;Expert Opin. Orphan Drugs;;
 Expert Opinion on Therapeutic Patents;Expert Opin. Ther. Pat.
 Exploration and Mining Geology;Explor. Min. Geol.
-Facial Plastic Surgery;Facial Plast. Surg.
-Falk Symposium;Falk Symp.
+Extractive Industries and Society;Extr. Ind. Soc.;;
+Extreme Mechanics Letters;Extreme Mech. Lett.;;
+Extreme Physiology & Medicine;Extreme Physiol. Med.;;
+F1000Research;F1000Research;;
 FAO Forestry Development Paper;FAO For. Dev. Pap.
-Faraday Discussions;Faraday Discuss.
-Farmaco;Farmaco
-Farmatsiya (Moscow);Farmatsiya (Moscow)
 FASEB Journal;FASEB J.
-Fatigue and Fracture of Engineering Materials and Structures;Fatigue Fract. Eng. Mater. Struct.
 FEBS Journal;FEBS J.
 FEBS Letters;FEBS Lett.
-Feddes Repertorium;Feddes Repert.
-Federal Register;Fed. Regist.
-Federation of European Biochemical Societies Letters;Fed. Eur. Biochem. Soc. Lett.
 FEMS Immunology and Medical Microbiology;FEMS Immunol. Med. Microbiol.
 FEMS Microbiology Ecology;FEMS Microbiol. Ecol.
 FEMS Microbiology Letters;FEMS Microbiol. Lett.
 FEMS Microbiology Reviews;FEMS Microbiol. Rev.
 FEMS Symposium;FEMS Symp.
 FEMS Yeast Research;FEMS Yeast Res.
+Facial Plastic Surgery;Facial Plast. Surg.
+Falk Symposium;Falk Symp.
+Faraday Discussions;Faraday Discuss.
+Farmaco;Farmaco
+Farmatsiya (Moscow);Farmatsiya (Moscow)
+Fashion and Textiles;Fashion Text.;;
+Fatigue and Fracture of Engineering Materials and Structures;Fatigue Fract. Eng. Mater. Struct.
+Feddes Repertorium;Feddes Repert.
+Federal Register;Fed. Regist.
+Federation of European Biochemical Societies Letters;Fed. Eur. Biochem. Soc. Lett.
 Fenxi Ceshi Tongbao;Fenxi Ceshi Tongbao
 Fenxi Huaxue;Fenxi Huaxue
 Fenxi Shiyanshi;Fenxi Shiyanshi
@@ -1416,25 +1695,26 @@ Fidia Research Foundation Symposium Series;Fidia Res. Found. Symp. Ser.
 Field Analytical Chemistry and Technology.;Field Anal. Chem. Technol.
 Field Studies;Field Stud.
 Filtration and Separation;Filtr. Sep.
+Fire Science Reviews;Fire Sci. Rev.;;
 Fire and Materials;Fire Mater.
 Fish Physiology and Biochemistry;Fish Physiol. Biochem.
 Fisheries Oceanography;Fish. Oceanogr.
-Fisheries Science (Carlton, Australia);Fish. Sci. (Carlton, Aust.)
 Fisheries Science;Fish. Sci.
+Fisheries Science (Carlton, Australia);Fish. Sci. (Carlton, Aust.)
 Fitoterapia;Fitoterapia
 Fizika Goreniya i Vzryva;Fiz. Goreniya Vzryva
-Fizika i Khimiya Obrabotki Materialov;Fiz. Khim. Obrab. Mater.
-Fizika i Khimiya Stekla;Fiz. Khim. Stekla
-Fizika i Tekhnika Poluprovodnikov (S. -Peterburg);Fiz. Tekh. Poluprovodn. (Leningrad)
 Fizika Metallov i Metallovedenie;Fiz. Met. Metalloved.
 Fizika Nizkikh Temperatur (Kiev);Fiz. Nizk. Temp. (Kiev)
 Fizika Plazmy (Moscow);Fiz. Plazmy (Moscow)
 Fizika Tverdogo Tela (S. -Peterburg);Fiz. Tverd. Tela (Leningrad)
+Fizika i Khimiya Obrabotki Materialov;Fiz. Khim. Obrab. Mater.
+Fizika i Khimiya Stekla;Fiz. Khim. Stekla
+Fizika i Tekhnika Poluprovodnikov (S. -Peterburg);Fiz. Tekh. Poluprovodn. (Leningrad)
 Fiziko-Khimicheskaya Mekhanika Materialov;Fiz.-Khim. Mekh. Mater.
 Fiziologicheskii Zhurnal imeni I. M. Sechenova;Fizziol. Zh. SSSR im I. M. Sechenova
 Fiziologichno Aktivni Rechovini;Fiziol. Akt. Rechovini
-Fiziologiya i Biokhimiya Kul'turnykh Rastenii;Fiziol. Biokhim. Kul't. Rast.
 Fiziologiya Rastenii (Moscow);Fiziol. Rast. (Moscow)
+Fiziologiya i Biokhimiya Kul'turnykh Rastenii;Fiziol. Biokhim. Kul't. Rast.
 Flora;Flora
 Florida Scientist;Fla. Sci.
 Floristische Rundbriefe;Florist. Rd.br.
@@ -1449,13 +1729,14 @@ Folia Geobotanica et Phytotaxonomica;Folia Geobot. Phytotaxon.
 Folia Microbiologica (Prague, Czech Republic);Folia Microbiol. (Prague, Czech Repub.)
 Fonderie Fondeur d'Aujourd'hui;Fonderie Fondeur Aujourd'hui
 Food Additives & Contaminants;Food Addit. Contam.
-Food and Chemical Toxicology;Food Chem. Toxicol.
-Food and Nutrition Bulletin;Food Nutr. Bull.
 Food Biotechnology;Food Biotechnol.
 Food Chemistry;Food Chem.
 Food Hydrocolloids;Food Hydrocolloids
 Food Science and Technology International;Food Sci. Technol. Int.
-Forest and Landscape Research;For. Landsc. Res.
+Food and Chemical Toxicology;Food Chem. Toxicol.
+Food and Energy Security;Food Energy Secur.;;
+Food and Nutrition Bulletin;Food Nutr. Bull.
+Forensic Science, Medicine, and Pathology;Forensic Sci. Med. Pathol.;;
 Forest Ecology and Management;For. Ecol. Manage.
 Forest Genetics;For. Genet.
 Forest Industries;For. Ind.
@@ -1465,6 +1746,7 @@ Forest Policy and Economics;For. Policy Econ.
 Forest Products Journal;For. Prod. J.
 Forest Science;For. Sci.
 Forest Snow and Landscape Research;For. Snow Landsc. Res.
+Forest and Landscape Research;For. Landsc. Res.
 Forestaviva;Forestaviva
 Forestry;Forestry
 Forestry Abstracts;For. Abstr.
@@ -1479,27 +1761,70 @@ Forstlich-naturwissenschaftliche Zeitschrift;Forstl.-nat.wiss. Z.
 Forstliche Forschungsberichte München;Forstl. Forsch.ber. Münch.
 Forstliche Rundschau;Forstl. Rundsch.
 Forstliche Umschau;Forstl. Umsch.
-forstlige forsøgsvaesen i Danmark, Det;Forstl. forsøgsvaes. Dan.
 Forstschutz Bulletin;Forstschutz Bull.
 Forsttechnische Informationen;Forsttech. Inf.
 Forstwissenschaftliches Centralblatt;Forstwiss. Cent.bl.
 Fortschriftsberiche der Deutschen Keramischen Gesellschaft;Fortschrittsber. Dtschen Keram. Ges.
-Forêt méditerranéenne;For. méditerr.
 Forêt Suisse;Forêt Suisse
-forêt, La;Forêt
+Forêt méditerranéenne;For. méditerr.
 Forêts de France;For. Fr.
 Forêts de France et action forestière;For. Fr. action for.
+Fossil Record;Fossil Rec.;;
 Free Radical Biology & Medicine;Free Radical Biol. Med.
 Free Radical Biology and Medicine;Free Radical Biol. Med.
 Free Radical Research;Free Radical Res.
 Free Radical Research Communications;Free Radical Res. Commun.
+Free Radicals and Antioxidants;Free Radicals Antioxid.;;
 Freiberger Forschungshefte A.;Freiberg. Forschungsh. A.
-Freiburger bodenkundliche Abhandlungen;Freibg. bodenkd. Abh.
 Freiburger Geographische Hefte;Freibg. Geogr. Hefte
 Freiburger Schriften zur Hydrologie;Freibg. Schr. Hydrol.
+Freiburger bodenkundliche Abhandlungen;Freibg. bodenkd. Abh.
 Fresenius Environmental Bulletin;Fresenius Environ. Bull.
 Fresenius' Journal of Analytical Chemistry;Fresenius. J. Anal. Chem.
+Frontiers in Aging Neuroscience;Front. Aging Neurosci.;;
+Frontiers in Aquatic Physiology;Front. Aquat. Physiol.;;
+Frontiers in Behavioral Neuroscience;Front. Behav. Neurosci.;;
+Frontiers in Bioengineering and Biotechnology;Front. Bioeng. Biotechnol.;;
+Frontiers in Cell and Developmental Biology;Front. Cell Dev. Biol.;;
+Frontiers in Cellular Neuroscience;Front. Cell. Neurosci.;;
+Frontiers in Cellular and Infection Microbiology;Front. Cell. Infect. Microbiol.;;
+Frontiers in Chemistry;Front. Chem.;;
+Frontiers in Computational Neuroscience;Front. Comput. Neurosci.;;
+Frontiers in Earth Science;Front. Earth Sci.;;
 Frontiers in Ecology and the Environment;Front. Ecol. Environ.
+Frontiers in Endocrinology;Front. Endocrinol.;;
+Frontiers in Energy Research;Front. Energy Res.;;
+Frontiers in Environmental Science;Front. Environ. Sci.;;
+Frontiers in Evolutionary Neuroscience;Front. Evolut. Neurosci.;;
+Frontiers in Genetics;Front. Genet.;;
+Frontiers in Human Neuroscience;Front. Hum. Neurosci.;;
+Frontiers in Immunology;Front. Immunol.;;
+Frontiers in Integrative Neuroscience;Front. Integr. Neurosci.;;
+Frontiers in Marine Science;Front. Mar. Sci.;;
+Frontiers in Materials;Front. Mater.;;
+Frontiers in Microbiology;Front. Microbiol.;;
+Frontiers in Molecular Neuroscience;Front. Mol. Neurosci.;;
+Frontiers in Neural Circuits;Front. Neural Circuits;;
+Frontiers in Neuroanatomy;Front. Neuroanat.;;
+Frontiers in Neuroendocrine Science;Front. Neuroendocr. Sci.;;
+Frontiers in Neuroenergetics;Front. Neuroenerg.;;
+Frontiers in Neuroengineering;Front. Neuroeng.;;
+Frontiers in Neuroinformatics;Front. Neuroinf.;;
+Frontiers in Neurology;Front. Neurol.;;
+Frontiers in Neurorobotics;Front. Neurorob.;;
+Frontiers in Neuroscience;Front. Neurosci.;;
+Frontiers in Oncology;Front. Oncol.;;
+Frontiers in Pediatrics;Front. Pediatr.;;
+Frontiers in Pharmacology;Front. Pharmacol.;;
+Frontiers in Physics;Front. Phys.;;
+Frontiers in Physiology;Front. Physiol.;;
+Frontiers in Plant Science;Front. Plant Sci.;;
+Frontiers in Psychiatry;Front. Psychiatry;;
+Frontiers in Psychology;Front. Psychol.;;
+Frontiers in Public Health;Front. Public Health;;
+Frontiers in Synaptic Neuroscience;Front. Synaptic Neurosci.;;
+Frontiers in Systems Neuroscience;Front. Syst. Neurosci.;;
+Frontiers in Zoology;Front. Zool.;;
 Frutticoltura;Frutticoltura
 Fuel;Fuel
 Fuel Cells (Weinheim, Germany);Fuel Cells (Weinheim, Ger.)
@@ -1517,6 +1842,11 @@ Fushe Fanghu;Fushe Fanghu
 Fusion Engineering and Design;Fusion Eng. Des.
 Fusion Science and Technology;Fusion Sci. Technol.
 Fusion Technology;Fusion Technol.
+GBF Monographs;GBF Monogr.
+GCB Bioenergy;GCB Bioenergy;;
+GIT Labor-Fachzeitschrift;GIT Labor Fachz.
+GIT, Fachzeitschrift für das Laboratorium;GIT, Fachz. Lab.
+Gaceta Medica de Mexico;Gac. Med. Mex.;;
 Gaia;Gaia
 Galvanotechnik;Galvanotechnik
 Gangtie;Gangtie
@@ -1533,39 +1863,45 @@ Gas, Wasser, Abwasser;Gas Wasser Abwasser
 Gastroenterology;Gastroenterology
 Gaswaerme International;Gaswaerme Int.
 Gazzetta Chimica Italiana;Gazz. Chim. Ital.
-GBF Monographs;GBF Monogr.
 Gefahrstoffe Reinhaltung der Luft;Gefahrstoffe - Reinhalt. Luft
 Gefiederte Welt, Die;Gefied.  Welt
 Gegenbaurs Morphologisches Jahrbuch;Gegenbaurs Morphol. Jahrb.
+Gems & Gemology;Gems Gemol.;;
 Gene;Gene
 Gene Expression Patterns;Gene Expression Patterns
 Gene Therapy;Gene Ther.
 Gene Therapy and Regulation;Gene Ther. Regul.
-General and Comparative Endocrinology;Gen. Comp. Endocrinol.
 General Pharmacology;Gen. Pharmacol.
 General Physiology and Biophysics;Gen. Physiol. Biophys.
 General Technical Report USDA Forest Service;Gen. Tech. Rep. USDA For. Serv.
+General and Comparative Endocrinology;Gen. Comp. Endocrinol.
 Genes & Development;Genes Dev.
 Genes to Cells;Genes Cells
 Genes, Chromosomes & Cancer;Genes, Chromosomes Cancer
 Genetic Analysis - Biomolecular Engineering;Genet. Anal. - Biomol. Eng.
+Genetic Testing and Molecular Biomarkers;Genet. Test. Mol. Biomarkers;;
 Genetical Research;Genet. Res.
 Genetics;Genetics
 Genetika (Moscow);Genetika (Moscow)
+Genome Integrity;Genome Integr.;;
 Genome Letters;Genome Lett.
+Genome Medicine;Genome Med.;;
 Genome Research;Genome Res.
 Genomics;Genomics
 Genshikaku Kenkyu;Genshikaku Kenkyu
 GeoAgenda;GeoAgenda
 Geobotanica selecta;Geobot. sel.
 Geochemical Journal;Geochem. J.
+Geochemical Perspectives;Geochem. Perspect.;;
 Geochemical Transactions;Geochem. Trans.
 Geochemistry International;Geochem. Int.
 Geochemistry, Geophysics, Geosystems;Geochem. Geophys. Geosyst.
 Geochemistry: Exploration, Environment, Analysis;Geochem.: Explor. Environ., Anal.
 Geochimica et Cosmochimica Acta;Geochim. Cosmochim. Acta
 Geoderma;Geoderma
+Geodermal Regional;Geodermal Reg.;;
 Geofisica pura e applicata;Geofis. pura appl.
+GeofÃsica Internacional;GeofÃs. Int.;;
 Geografiska Annaler;Geogr. Ann.
 Geographica Bernensia;Geogr. Bern.
 Geographica Helvetica;Geogr. Helv.
@@ -1583,33 +1919,37 @@ Geologiya i Geofizika;Geol Geofiz
 Geology;Geology
 Geomagnetizm i Aeronomiya;Geomagn. Aeron.
 Geomicrobiology Journal;Geomicrobiol. J.
-Geophysical and Astrophysical Fluid Dynamics;Geophys. Astrophys. Fluid Dyn.
 Geophysical Journal;Geophys. J
 Geophysical Magazine;Geophys. Mag.
 Geophysical Prospecting;Geophys. Prospect.
 Geophysical Research Letters;Geophys. Res. Lett.
-Geophysical Research Letters;Geophys. Res. Lett.
+Geophysical and Astrophysical Fluid Dynamics;Geophys. Astrophys. Fluid Dyn.
+Geoscience Data Journal;Geosci. Data J.;;
+Geoscience Frontiers;Geosci. Front.;;
+Geoscientific Instrumentation, Methods and Data Systems;Geosci. Instrum. Methods Data Syst.;;
+Geoscientific Instrumentation, Methods and Data Systems Discussions;Geosci. Instrum. Methods Data Syst. Discuss.;;
+Geoscientific Model Development;Geosci. Model Dev.;;
+Geoscientific Model Development Discussions;Geosci. Model Dev. Discuss.;;
 Geotechnical Testing Journal;Geotech. Test. J.
+Geothermal Energy Science;Geotherm. Energy Sci.;;
 Gesetzgebung des Bundes und der Kantone;Gesetzgeb. Bundes Kantone
 Gewaesserschutz, Wasser, Abwasser;Gewaesserschutz, Wasser, Abwasser
 Gidrokhimicheskie Materialy;Gidrokhim. Mat.
 Giessener Geographische Schriften;Giess. Geogr. Schr.
-Gigiena i Sanitariya;Gig. Sanit.
 Gigiena Truda i Professional'nye Zabolevaniya;Gig. Tr. Prof. Zabol.
+Gigiena i Sanitariya;Gig. Sanit.
 Giornale del Popolo;G. Pop.
-GIT Labor-Fachzeitschrift;GIT Labor Fachz.
-GIT, Fachzeitschrift für das Laboratorium;GIT, Fachz. Lab.
-Glass and Ceramics;Glass Ceram.
 Glass Physics and Chemistry;Glass Phys. Chem.
 Glass Research;Glass Res.
 Glass Science and Technology (Offenbach, Germany);Glass Sci. Technol. (Offenbach, Ger.)
 Glass Technology;Glass Technol.
 Glass Technology: European Journal of Glass Science and Technology, Part A;Glass Technol.: Eur. J. Glass Sci. Technol., Part A
+Glass and Ceramics;Glass Ceram.
 GlassResearcher;GlassResearcher
-Global Biogeochemical Cycles;Glob. Biogeochem. Cycles
 Global Biogeochemical Cycles;Global Biogeochem. Cycles
 Global Change Biology;Glob. Chang. Biol.
 Global Ecology and Biogeography Letters;Glob. Ecol. Biogeogr. Lett.
+Global Ecology and Conservation;Global Ecol. Conserv.;;
 Global Environmental Change;Glob. Environ. Chang.
 Global Journal of Pure and Applied Sciences;Global J. Pure Appl. Sci.
 Glycobiology;Glycobiology
@@ -1620,6 +1960,9 @@ Graphis Scripta;Graph. Scr.
 Grasas y Aceites (Seville);Grasas Aceites (Seville)
 Great Basin Naturalist;Gt. Basin Nat.
 Green Chemistry;Green Chem.
+Green Materials;Green Mater.;;
+Green and Sustainable Chemistry;Green Sustainable Chem.;;
+Greenhouse Gases: Science and Technology;Greenhouse Gases Sci. Technol.;;
 Ground Water;Ground Water
 Ground Water Monitoring and Remediation;Ground Water Monit. Rem.
 Growth Factors;Growth Factors
@@ -1630,23 +1973,27 @@ Guijinshu;Guijinshu
 Guisuanyan Xuebao;Guisuanyan Xuebao
 Guocheng Gongcheng Xuebao;Guocheng Gongcheng Xuebao
 Géographie Physique et Quaternaire;Géogr. Phys. Quat.
+HESPA Mitteilungen;HESPA Mitt.
+HRC Journal of High Resolution Chromatography;HRC J. High Resolut. Chromatogr.
+HTD (American Society of Mechanical Engineers);HTD (Am. Soc. Mech. Eng.)
+HTM, Haerterei-Technische Mitteilungen;HTM, Haerterei Tech. Mit.
 Han'guk Saenghwa Hakhoechi;Han'guk Saenghwa Hakhoechi
 Han'guk T'oyang Piryo Hakhoechi;Han'guk T'oyang Piryo Hakhoechi
 Handbook of Experimental Pharmacology;Handb. Exp. Pharmacol.
 Handbook of Vegetation Science;Handb. Veg. Sci.
 Hazardous Waste and Hazardous Materials;Hazard. Waste Hazard. Mater.
 Health Physics;Health Phys.
-Heat and Mass Transfer;Heat Mass Transfer.
 Heat Transfer Engineering;Heat Transfer Eng.
 Heat Treatment of Metals;Heat Treat. Met.
+Heat and Mass Transfer;Heat Mass Transfer.
 Hecheng Xiangjiao Gongye;Hecheng Xiangjiao Gongye
 Hejishu;Hejishu
+Helgoland Marine Research;Helgol. Mar. Res.;;
 Helvetia Archaeologica;Helv. Archaeol.
 Helvetica Chimica Acta;Helv. Chim. Acta
 Hemoglobin;Hemoglobin
 Heredity;Heredity
 Herzogia;Herzogia
-HESPA Mitteilungen;HESPA Mitt.
 Hessische Floristische Briefe;Hess. Florist. Briefe
 Heteroatom Chemistry;Heteroat. Chem.
 Heterocycles;Heterocycles
@@ -1654,6 +2001,7 @@ Heterocyclic Communications;Heterocycl. Commun.
 Heterogeneous Chemistry Reviews;Heterogen. Chem. Rev.
 High Energy Chemistry;High Energy Chem.
 High Performance Polymers;High Perform. Polym.
+High Power Laser Science and Engineering;High Power Laser Sci. Eng.;;
 High Temperature;High Temp.
 High Temperature Material Processes;High Temp. Mater. Processes (New York)
 High Temperature Materials and Processes (London, United Kingdom);High Temp. Mater. Processes (London, U. K.)
@@ -1662,6 +2010,7 @@ High Temperatures - High Pressures;High Temp. - High Pressures
 Histochemical Journal;Histochem. J.
 Histochemistry;Histochemistry
 Histochemistry and Cell Biology;Histochem. Cell Biol.
+History of Geo- and Space Science;Hist. Geo Space Sci.;;
 Holarctic Ecology;Holarct. Ecol.
 Holocene, The;Holocene
 Holz als Roh und Werkstoff;Holz Roh Werkst.
@@ -1676,15 +2025,13 @@ Holzforschung und Holzverwertung;Holzforsch. Holzverwert.
 Holzpreisstatistik – Rohholz;Holzpreisstat. – Rohholz
 Holzzucht, Die;Holzzucht
 Hoppe-Seyler's Zeitschrift für Physiologische Chemie;Hoppe-Seyler's Z. Physiol. Chem.
-Hormone and Metabolic Research;Horm. Metab. Res.
 Hormone Research;Horm. Res.
+Hormone and Metabolic Research;Horm. Metab. Res.
 HortScience;HortScience
 Horumon to Rinsho;Horumon to Rinsho
 Hotel + Touristik Revue;Hotel Tour. Rev.
 Hotel Journal;Hotel J.
-HRC Journal of High Resolution Chromatography;HRC J. High Resolut. Chromatogr.
-HTD (American Society of Mechanical Engineers);HTD (Am. Soc. Mech. Eng.)
-HTM, Haerterei-Technische Mitteilungen;HTM, Haerterei Tech. Mit.
+Household & Personal Products Industry;Household Pers. Prod. Ind.;;
 Huadong Huagong Xueyuan Xuebao;Huadong Huagong Xueyuan Xuebao
 Huadong Ligong Daxue Xuebao;Huadong Ligong Daxue Xuebao
 Huadong Ligong Daxue Xuebao, Ziran Kexueban;Huadong Ligong Daxue Xuebao, Ziran Kexueban
@@ -1699,18 +2046,23 @@ Huaxue Shijie;Huaxue Shijie
 Huaxue Tongbao;Huaxue Tongbao
 Huaxue Wuli Xuebao;Huaxue Wuli Xuebao
 Huaxue Xuebao;Huaxue Xuebao
+Human & Experimental Toxicology;Hum. Exp. Toxicol.;;
 Human Ecology;Hum. Ecol.
 Human Gene Therapy;Hum. Gene Ther.
+Human Gene Therapy Clinical Development;Hum. Gene Ther. Clin. Dev.;;
+Human Gene Therapy Methods;Hum. Gene Ther. Methods;;
 Human Genetics;Hum. Genet.
+Human Genome Variation;Hum. Genome Var.;;
 Human Molecular Genetics;Hum. Mol. Genet.
 Human Organization;Hum. Organ.
+Human Pathology: Case Reports;Hum. Pathol.: Case Rep.;;
+Human Psychopharmacology;Hum. Psychopharmacol.;;
 Human Reproduction;Hum. Reprod.
 Humic Substances in the Environment;Humic Subst. Environ.
 Hungarian Journal of Industrial Chemistry;Hung. J. Ind. Chem.
 Hutnicke Listy;Hutn. Listy
 Hwahak Konghak;Hwahak Konghak
 Hwahak Kwa Kongop Ui Chinbo;Hwahak Kwa Kongop Ui Chinbo
-Hydrobiologia;Hydrobiologia
 Hydrobiologia;Hydrobiologia
 Hydrocarbon Processing, International Edition;Hydrocarbon Process., Int. Ed.
 Hydrological Processes;Hydrol. Process.
@@ -1720,35 +2072,38 @@ Hydrologie und Wasserbewirtschaftung;Hydrol. Wasserbewirtsch.
 Hydrometallurgy;Hydrometallurgy
 Hyomen Gijutsu;Hyomen Gijutsu
 Hyperfine Interactions;Hyperfine Interact.
-Hypertension (Dallas);Hypertension (Dallas)
 Hypertension;Hypertension
+Hypertension (Dallas);Hypertension (Dallas)
 IAHS (International Association of Hydrological Sciences) Publication;IAHS Publ.
 IALE (International Association for Landscape Ecology) Bulletin;IALE (International Association for Landscape Ecology) Bull.
 IARC Scientific Publications;IARC Sci. Publ.
 IAWA (International Association of Wood Anatomists) Journal;IAWA J.
-Ibis;Ibis
+IB Scientific Journal of Science;IB Sci. J. Sci.;;
 IBM-Nachrichten;IBM-Nachr.
-Icarus;Icarus
 ICIS Chemical Business;ICIS Chem. Bus.
 ICIS Chemical Business Americas;ICIS Chem. Bus. Am.
 ICSU Short Reports;ICSU Short Rep.
+IDA Journal of Desalination and Water Reuse;IDA J. Desalin. Water Reuse;;
+IEE Journal on Computers and Digital Techniques;IEE J. Comput. Digital Tech.;;
+IEE Journal on Electric Power Applications;IEE J. Electr. Power Appl.;;
+IEE Journal on Microwaves, Antennas & Propagation;IEE J. Microwaves Antennas Propag.;;
 IEE Proceedings: Optolectronics;IEE Proc.: Optoelectron.
 IEE Proceedings: Science, Measurement & Technology;IEE Proc.: Sci. Meas. Technol.
+IEEE ASSP Magazine;IEEE ASSP Mag.
+IEEE ASSP Magazine (1984-1990);IEEE ASSP Mag.
 IEEE Aerospace and Electronics Systems Magazine;IEEE Aerosp. Electron. Syst. Mag.
 IEEE Annals of the History of Computing;IEEE Annals Hist. Comput.
 IEEE Antennas and Propagation Magazine;IEEE Antennas Propagat. Mag.
 IEEE Antennas and Wireless Propagation Letters;IEEE Antennas Wireless Propagat. Lett.
-IEEE ASSP Magazine (1984-1990);IEEE ASSP Mag.
-IEEE ASSP Magazine;IEEE ASSP Mag.
-IEEE Circuits and Devices Magazine (1985-present);IEEE Circuits Devices Mag.
 IEEE Circuits and Devices Magazine;IEEE Circuits Devices Mag.
-IEEE Circuits and Systems Magazine (1979-1984);IEEE Circuits Syst. Mag.
+IEEE Circuits and Devices Magazine (1985-present);IEEE Circuits Devices Mag.
 IEEE Circuits and Systems Magazine;IEEE Circuits Syst. Mag.
+IEEE Circuits and Systems Magazine (1979-1984);IEEE Circuits Syst. Mag.
 IEEE Communications Letters;IEEE Commun. Lett.
-IEEE Communications Magazine (1979-present);IEEE Commun. Mag.
 IEEE Communications Magazine;IEEE Commun. Mag.
-IEEE Communications Society Magazine (through 1978);IEEE Commun. Soc. Mag.
+IEEE Communications Magazine (1979-present);IEEE Commun. Mag.
 IEEE Communications Society Magazine;IEEE Commun. Soc. Mag.
+IEEE Communications Society Magazine (through 1978);IEEE Commun. Soc. Mag.
 IEEE Computation in Science and Engineering Magazine;IEEE Comput. Sci. Eng. Mag.
 IEEE Computational Intelligence Magazine;IEEE Comput. Intell. Mag.
 IEEE Computational Science & Engineering;IEEE Comput. Sci. Eng.
@@ -1764,18 +2119,18 @@ IEEE Distributed Systems Online;IEEE Distrib. Syst. Online
 IEEE Electrical Insulation Magazine;IEEE Electr. Insul. Mag.
 IEEE Electromagnetic Compatibility Symposium Record;IEEE Electroman. Comp.
 IEEE Electron Device Letters;IEEE Electron Device Lett.
-IEEE Engineering in Medicine and Biology Magazine;IEEE Eng. Med. Biol. Mag.
 IEEE Engineering Management Review;IEEE Eng. Manag. Rev.
-IEEE Expert (through 1997);IEEE Expert
+IEEE Engineering in Medicine and Biology Magazine;IEEE Eng. Med. Biol. Mag.
 IEEE Expert;IEEE Expert
+IEEE Expert (through 1997);IEEE Expert
 IEEE Expert-intelligent Systems & their Applications;IEEE Expert.
 IEEE Geoscience and Remote Sensing Letters;IEEE Geosci. Remote. S.
+IEEE IT Professional;IEEE IT Prof.
 IEEE Industry Applications Magazine;IEEE Ind. Appl. Mag.
 IEEE Instrumentation and Measurement Magazine;IEEE Instrum. Meas. Mag.
-IEEE Intelligent Systems & their Applications;IEEE Intell. Syst. App.
 IEEE Intelligent Systems;IEEE Intell. Syst.
+IEEE Intelligent Systems & their Applications;IEEE Intell. Syst. App.
 IEEE Internet Computing;IEEE Internet. Comput.
-IEEE IT Professional;IEEE IT Prof.
 IEEE Journal of Oceanic Engineering;IEEE J. Oceanic. Eng.
 IEEE Journal of Quantum Electronics;IEEE J. Quantum. Electron.
 IEEE Journal of Robotics and Automation;IEEE J. Robotic. Autom.
@@ -1784,9 +2139,9 @@ IEEE Journal of Solid-State Circuits;IEEE J. Solid-State Circuits
 IEEE Journal on Selected Areas in Communications;IEEE J. Select. Areas Commun.
 IEEE Journal on Technology in Computer Aided Design;IEEE J. Technol. Computer Aided Design
 IEEE Micro;IEEE Micro
+IEEE Microwave Magazine;IEEE Microwave
 IEEE Microwave and Guided Wave Letters;IEEE Microwave Guided Wave Lett.
 IEEE Microwave and Wireless Components Letters;IEEE Microwave Wireless Compon. Lett.
-IEEE Microwave Magazine;IEEE Microwave
 IEEE Multimedia;IEEE Multimedia
 IEEE Network;IEEE Network
 IEEE Parallel & Distributed Technology;IEEE Parall. Distrib.
@@ -1795,14 +2150,14 @@ IEEE Personal Communications Magazine;IEEE Personal Commun. Mag.
 IEEE Pervasive Computing;IEEE Pervas. Comput.
 IEEE Photonics Technology Letters;IEEE Photon. Technol. Lett.
 IEEE Potentials;IEEE Potentials
-IEEE Power and Energy Magazine;IEEE Power Energy Mag.
 IEEE Power Engineering Review;IEEE Power Eng. Rev.
+IEEE Power and Energy Magazine;IEEE Power Energy Mag.
 IEEE Robotics and Automation Magazine;IEEE Robot. Automat. Mag.
 IEEE Security & Privacy;IEEE Secur. Priv.
 IEEE Sensors Journal;IEEE Sens. J.
 IEEE Signal Processing Letters;IEEE Signal Processing Lett.
-IEEE Signal Processing Magazine (1991-present);IEEE Signal Process. Mag.
 IEEE Signal Processing Magazine;IEEE Signal Processing Mag.
+IEEE Signal Processing Magazine (1991-present);IEEE Signal Process. Mag.
 IEEE Software;IEEE Softw.
 IEEE Spectrum;IEEE Spectr.
 IEEE Technology and Society Magazine;IEEE Technol. Soc. Mag.
@@ -1817,8 +2172,8 @@ IEEE Transactions on Antennas and Propagation;IEEE Trans. Antennas Propagat.
 IEEE Transactions on Applications and Industry;IEEE Trans. Applicat. Ind.
 IEEE Transactions on Applied Superconductivity;IEEE Trans. Appl. Superconduct.
 IEEE Transactions on Audio;IEEE Trans. Audio
-IEEE Transactions on Audio and Electroacoustics;IEEE Trans. Audio Electroacoust.
 IEEE Transactions on Audio Speech and Language Processing;IEEE Trans. Audio. Speech.
+IEEE Transactions on Audio and Electroacoustics;IEEE Trans. Audio Electroacoust.
 IEEE Transactions on Automatic Control;IEEE Trans. Automat. Contr.
 IEEE Transactions on Automation Science and Engineering;IEEE Trans. Automat. Sci. Eng.
 IEEE Transactions on Bio-Medical Engineering;IEEE Trans. Bio-Med. Eng.
@@ -1827,20 +2182,18 @@ IEEE Transactions on Broadcast and Television Receivers;IEEE Trans. Broadc. Tele
 IEEE Transactions on Broadcasting;IEEE Trans. Broadcast.
 IEEE Transactions on Circuit Theory;IEEE Trans. Circuit Theory
 IEEE Transactions on Circuits and Systems;IEEE Trans. Circuits Syst.
-IEEE Transactions on Circuits and Systems for Video Technology;IEEE Trans. Circuits Syst. Video Technol.
 IEEE Transactions on Circuits and Systems I-Fundamental Theory and Applications;IEEE Trans. Circuits Syst. I
-IEEE Transactions on Circuits and Systems I-Regular Papers;IEEE Trans. Circuits Syst. I
 IEEE Transactions on Circuits and Systems I-Regular Papers;IEEE Trans. Circuits-I.
 IEEE Transactions on Circuits and Systems II-Analog and Digital Signal Processing;IEEE Trans. Circuits Syst. II
 IEEE Transactions on Circuits and Systems II-Express Briefs;IEEE Trans. Circuits Syst. II
+IEEE Transactions on Circuits and Systems for Video Technology;IEEE Trans. Circuits Syst. Video Technol.
 IEEE Transactions on Circuits and Systems---Part I: Fundamental Theory and Applications;IEEE Trans. Circuits Syst. I
 IEEE Transactions on Circuits and Systems---Part II: Analog and Digital Signal Processing;IEEE Trans. Circuits Syst. II
-IEEE Transactions on Communication and Electronics;IEEE Trans. Commun. Electr.
 IEEE Transactions on Communication Technology;IEEE Trans. Commun. Technol.
+IEEE Transactions on Communication and Electronics;IEEE Trans. Commun. Electr.
 IEEE Transactions on Communications;IEEE Trans. Commun.
 IEEE Transactions on Communications Systems;IEEE Trans. Commun. Syst.
 IEEE Transactions on Component Parts;IEEE Trans. Comp. Parts
-IEEE Transactions on Components and Packaging Technologies;IEEE Trans. Comp. Packag. Technol.
 IEEE Transactions on Components and Packaging Technologies;IEEE Trans. Comp. Packag. Technol.
 IEEE Transactions on Components and Packaging Technology;IEEE Trans. Comp. Packag. Technol.
 IEEE Transactions on Components, Hybrids and Manufacturing Technology;IEEE Trans. Comp., Hybrids, Manufact. Technol.
@@ -1865,16 +2218,15 @@ IEEE Transactions on Engineering Management;IEEE Trans. Eng. Manage.
 IEEE Transactions on Engineering Writing and Speech;IEEE Trans. Prof. Commun.
 IEEE Transactions on Evolutionary Computation;IEEE Trans. Evol. Comput.
 IEEE Transactions on Fuzzy Systems;IEEE Trans. Fuzzy Syst.
-IEEE transactions on Geoscience and Remote Sensing;IEEE Trans. Geosci. Remote Sens.
-IEEE Transactions on Geoscience and Remote Sensing;IEEE Trans. Geosci. Remote Sensing
 IEEE Transactions on Geoscience Electronics;IEEE Trans. Geosci. Electron.
+IEEE Transactions on Geoscience and Remote Sensing;IEEE Trans. Geosci. Remote Sensing
 IEEE Transactions on Human Factors in Electronics;IEEE Trans. Hum. Factors Electron.
 IEEE Transactions on Human Factors in Engineering;IEEE Trans. Hum. Factors Eng.
 IEEE Transactions on Image Processing;IEEE Trans. Image Processing
 IEEE Transactions on Industrial Electronics;IEEE Trans. Ind. Electron.
 IEEE Transactions on Industrial Electronics and Control Instrumentation;IEEE Trans. Ind. Electron. Contr. Instrum.
-IEEE Transactions on Industry and General Applications;IEEE Trans. Ind. Gen. Applicat.
 IEEE Transactions on Industry Applications;IEEE Trans. Ind. Applicat.
+IEEE Transactions on Industry and General Applications;IEEE Trans. Ind. Gen. Applicat.
 IEEE Transactions on Information Technology in Biomedicine;IEEE Trans. Inform. Technol. Biomed.
 IEEE Transactions on Information Theory;IEEE Trans. Inform. Theory
 IEEE Transactions on Instrumentation and Measurement;IEEE Trans. Instrum. Meas.
@@ -1932,6 +2284,7 @@ IEEE Translation Journal on Magnetics in Japan;IEEE Transl. J. Magn. Jpn.
 IEEE Vehicular Technology Group-Annual Conference;IEEE Veh. Technol. Group
 IEEE Wireless Communications;IEEE Wireless Commun.
 IEEE Wireless Communications Magazine;IEEE Wireless Commun. Mag.
+IEEE transactions on Geoscience and Remote Sensing;IEEE Trans. Geosci. Remote Sens.
 IEEE-ACM Transactions on Computational Biology and Bioinformatics;IEEE-ACM Trans. Comput. Bi.
 IEEE-ACM Transactions on Computational Biology and Bioinformatiocs;IEEE-ACM Trans. Comput. Bi.
 IEEE-ACM Transactions on Networking;IEEE ACM Trans. Network.
@@ -1940,6 +2293,8 @@ IEEE/ACM Transactions on Networking;IEEE/ACM Trans. Networking
 IEEE/ASME Journal of Microelectromechanical Systems;J. Microelectromech. Syst.
 IEEE/ASME Transactions on Mechatronics;IEEE/ASME Trans. Mechatron.
 IEEE/OSA Journal of Lightwave Technology;J. Lightwave Technol.
+IEEJ Transactions on Electrical and Electronic Engineering;IEEJ Trans. Electr. Electron. Eng.;;
+IET Biometrics;IET Biom.;;
 IET Circuits, Devices and Systems;IET Circuits Devices Syst.
 IET Communications;IET Commun.
 IET Communications Engineer;IET Commun. Eng.
@@ -1947,15 +2302,20 @@ IET Computer Vision;IET Comput. Vision
 IET Computers and Digital Techniques;IET Comput. Digital Tech.
 IET Control Theory and Applications;IET Control Theory Appl.
 IET Electric Power Applications;IET Electr. Power Appl.
+IET Electrical Systems in Transportation;IET Electr. Syst. Transp.;;
 IET Electronics Systems and Software;IET Electron. Syst. Softw.
 IET Engineering Management;IET Eng. Manage.
 IET Generation, Transmission and Distribution;IET Gener. Transm. Distrib.
 IET Image Processing;IET Image Proc.
 IET Information Security;IET Inf. Secur.
 IET Intelligent Transport Systems;IET Intel. Transport Syst.
+IET Manufacturing;IET Manuf.;;
+IET Micro & Nano Letters;IET Micro Nano Lett.;;
 IET Microwaves, Antennas and Propagation;IET Microwaves Antennas Propag.
 IET Nanobiotechnology;IET Nanobiotechnol.
+IET Networks;IET Networks;;
 IET Optoelectronics;IET Optoelectron
+IET Power Electronics;IET Power Electron.;;
 IET Power Engineer;IET Power Eng.
 IET Proceedings: Science, Measurement & Technology;IET Proc.: Sci. Meas. Technol.
 IET Radar, Sonar and Navigation;IET Radar Sonar Navig.
@@ -1965,9 +2325,20 @@ IET Signal Processing;IET Signal Proc.
 IET Software;IET Software
 IET Synthetic Biology;IET Synth. Biol.
 IET Systems Biology;IET Syst. Biol.
+IET Wireless Sensor Systems;IET Wireless Sens. Syst.;;
+IIE Transactions on Occupational Ergonomics & Human Factors;IIE Trans. Occup. Ergon. Hum. Factors;;
 ILAR Journal;ILAR J.
+IOWA Agricultural Experiment Station Research Bulletin;IOWA Agric. Exp. Stn. Res. Bull.
+ISIJ International;ISIJ Int.
+ISME Journal;ISME J.;;
+IT Professional;IT Prof.;;
+ITC-Journal;ITC-J.
+IUBMB Life;IUBMB Life
+Ibis;Ibis
+Icarus;Icarus
 Im Dienste von Wald und Landschaft;Im Dienste Wald Landsch.
 Immunity;Immunity
+Immunity, Inflammation and Disease;Immun. Inflammation Dis.;;
 Immunobiology;Immunobiology
 Immunogenetics;Immunogenetics
 Immunology;Immunology
@@ -1975,6 +2346,8 @@ Immunology Letters;Immunol. Lett.
 Immunology Today;Immunol. Today
 Immunology, Endocrine & Metabolic Agents in Medicinal Chemistry;Immunol., Endocr. Metab. Agents Med. Chem.
 Impartial, L';Impartial
+In Vitro Cellular & Developmental Biology: Animal;In Vitro Cell. Dev. Biol. Anim.;;
+In Vitro Cellular & Developmental Biology: Plant;In Vitro Cell. Dev. Biol. Plant;;
 Indian Chemical Engineer;Indian Chem. Eng.
 Indian Drugs;Indian Drugs
 Indian Journal of Agricultural Chemistry;Indian J. Agric. Chem.
@@ -1994,15 +2367,16 @@ Indian Journal of Physics, B;Indian J. Phys., B
 Indian Journal of Pure and Applied Physics;Indian J. Pure Appl. Phys.
 Indian Journal of Technology;Indian J. Technol.
 Industrial & Engineering Chemistry Research;Ind. Eng. Chem. Res.
+Industrial Diamond Review;Ind. Diamond Rev.
 Industrial and Engineering Chemistry;Ind. Eng. Chem.
 Industrial and Engineering Chemistry Fundamentals;Ind. Eng. Chem. Fundam.
 Industrial and Engineering Chemistry, Analytical Edition;Ind. Eng. Chem., Anal. Ed.
-Industrial Diamond Review;Ind. Diamond Rev.
 Industrielle Organisation;Ind. Organ.
 Infection and Immunity;Infect. Immun.
 Infectious Disorders: Drug Targets;Infect. Disord.: Drug Targets
 Inflammation & Allergy: Drug Targets;Inflammation Allergy: Drug Targets
 Inflammation Research;Inflammation Res.
+Information Professional;Inf. Prof.;;
 Information Report Northern Forest Research Centre;Inf. Rep. North. For. Res. Cent.
 Information Zürcher Wald;Inf. Zür. Wald
 Informationen zu Naturschutz und Landschaftspflege in Nordwestdeutschland;Inf. Nat.schutz Landsch.pfl. Nordwestdtschl.
@@ -2016,12 +2390,12 @@ Infrared Physics and Technology;Infrared Phys. Technol.
 Ingenieria Quimica (Madrid);Ing. Quim.
 Ingenieurbiologie Mitteilungsblatt;Ing.biol. Mitt.bl.
 Inhalation Toxicology;Inhalation Toxicol.
-Inorganic Chemistry (Washington, DC, United States);Inorg. Chem. (Washington, DC, U. S.)
 Inorganic Chemistry;Inorg. Chem.
+Inorganic Chemistry (Washington, DC, United States);Inorg. Chem. (Washington, DC, U. S.)
 Inorganic Chemistry Communications;Inorg. Chem. Commun.
 Inorganic Materials;Inorg. Mater.
-Inorganic Reaction Mechanisms (Philadelphia, PA, United States);Inorg. React. Mech. (Philadelphia, PA, U. S.)
 Inorganic Reaction Mechanisms;Inorg. React. Mech.
+Inorganic Reaction Mechanisms (Philadelphia, PA, United States);Inorg. React. Mech. (Philadelphia, PA, U. S.)
 Inorganic Syntheses;Inorg. Synth.
 Inorganica Chimica Acta;Inorg. Chim. Acta
 Insect Biochemistry and Molecular Biology;Insect Biochem. Mol. Biol.
@@ -2030,9 +2404,12 @@ Institute of Physics Conference Series;Inst. Phys. Conf. Ser.
 Institution of Chemical Engineers Symposium Series;Inst. Chem. Eng. Symp. Ser.
 Instrumentation Science & Technology;Instrum. Sci. Technol.
 Integrated Ferroelectronics;Integr. Ferroelectr.
+Intelligent Systems Engineering;Intell. Syst. Eng.;;
+Interdisciplinary Neurosurgery: Advanced Techniques and Case Management;Interdiscip. Neurosurg. Adv. Tech. Case Manage.;;
 Interface Science;Interface Sci.
 Intermetallics;Intermetallics
 International Annual Conference of ICT;Int. Annu. Conf. ICT
+International Aquatic Research;Int. Aquat. Res,;;
 International Archives of Allergy and Immunology;Int. Arch. Allergy Appl. Immunol.
 International Archives of Photogrammetry and Remote Sensing;Int. Arch. Photogramm. Remote Sens.
 International Biodeterioration and Biodegradation;Int. Biodeterior. Biodegrad.
@@ -2048,55 +2425,80 @@ International Journal for Numerical Methods in Fluids;Int. J. Numer. Methods Flu
 International Journal for Simulation and Multidisciplinary Design Optimization;Int. J. Simul. Multi. Design Optim.
 International Journal for Vitamin and Nutrition Research;Int. J. Vitam. Nutr. Res.
 International Journal of Adhesion and Adhesives;Int. J. Adhes. Adhes.
+International Journal of Aeronautical and Space Sciences;Int. J. Aeronaut. Space Sci.;;
 International Journal of Antimicrobial Agents;Int. J. Antimicrob. Agents
 International Journal of Applied Ceramic Technology;Int. J. Appl. Ceram. Technol.
+International Journal of Applied Science and Technology;Int. J. Appl. Sci. Technol.;;
 International Journal of Aromatherapy;Int. J. Aromather.
-International Journal of Biochemistry & Cell Biology;Int. J. Biochem. Cell Biol.
 International Journal of Biochemistry;Int. J. Biochem.
+International Journal of Biochemistry & Cell Biology;Int. J. Biochem. Cell Biol.
 International Journal of Biochromatography;Int. J. Bio-Chromatogr.
 International Journal of Biological Chemistry;Int. J. Biol. Chem.
 International Journal of Biological Macromolecules;Int. J. Biol. Macromol.
 International Journal of Biometeorologie;Int. J. Biometeorol.
 International Journal of Cancer;Int. J. Cancer
+International Journal of Cardiology-Heart & Vessels;Int. J. Cardiol. Heart Vessels;;
+International Journal of Cardiology-Metabolic & Endocrine;Int. J. Cardol. Metab. Endocr.;;
 International Journal of Cast Metals Research;Int. J. Cast Met. Res.
 International Journal of Chemical Kinetics;Int. J. Chem. Kinet.
 International Journal of Chemical Reactor Engineering;Int. J. Chem. Reactor Eng. ??
+International Journal of Chemical and Analytical Science;Int. J. Chem. Anal. Sci.;;
 International Journal of Chemistry;Int. J. Chem.
+International Journal of Child-Computer Interaction;Int. J. Child-Comput. Interact.;;
+International Journal of Climate Change Strategies and Management;Int. J. Clim. Change Strategies Manage.;;
 International Journal of Climatology;Int. J. Climatol.
+International Journal of Clinical and Experimental Medicine;Int. J. Clin. Exp. Med.;;
+International Journal of Clinical and Experimental Pathology;Int. J. Clin. Exp. Path.;;
 International Journal of Coal Geology;Int. J. Coal Geol.
+International Journal of Current Chemistry;Int. J. Curr. Chem.;;
+International Journal of Current Trends in Science and Technology;Int. J. Curr. Trends Sci. Technol.;;
+International Journal of Dental Science and Research;Int. J. Dent. Sci. Res.;;
+International Journal of Disaster Risk Reduction;Int. J. Disaster Risk Reduct.;;
+International Journal of Electrical, Computer, and Systems Engineering;Int. J. Electr. Comput. Syst. Eng.;;
 International Journal of Electrochemical Science;Int. J. Electrochem. Sci.
+International Journal of Endocrinology and Metabolism;Int. J. Endocrinol. Metab.;;
+International Journal of Energy and Environment;Int. J. Energy Environ.;;
 International Journal of Engineering;Int. J. Eng.
 International Journal of Engineering, Transactions A:;Int. J. Eng., Trans. A:
 International Journal of Environment and Pollution;Int. J. Environ. Pollut.
 International Journal of Environmental Analytical Chemistry;Int. J. Environ. Anal. Chem.
 International Journal of Essential Oil THerapeutics;Int. J. Essen. Oil Ther.
 International Journal of Fatigue;Int. J. Fatigue
+International Journal of Food Contamination;Int. J. Food Contam.;;
 International Journal of Food Science and Technology;Int. J. Food Sci. Technol.
+International Journal of Geo-Engineering;Int. J. Geo-Eng.;;
 International Journal of Geographical Information Systems;Int. J. Geogr. Inf. Syst.
-International Journal of Heat and fluid flow;Int. J. Heat Fluid Flow
+International Journal of Green Nanotechnology;Int. J. Green Nanotechnol.;;
 International Journal of Heat and Mass Transfer;Int. J. Heat Mass Transfer
+International Journal of Heat and fluid flow;Int. J. Heat Fluid Flow
 International Journal of Hydrogen Energy;Int. J. Hydrogen Energy
 International Journal of Immunogenetics;Int. J. Immunogenet.
+International Journal of Immunopathology and Pharmacology;Int.. J. Immunopathol. Pharmacol.;;
 International Journal of Immunopharmacology;Int. J. Immunopharmacol
 International Journal of Impact Engineering;Int. J. Impact Eng.
 International Journal of Infrared and Millimeter Waves;Int. J. Infrared Millimeter Waves
 International Journal of Inorganic Materials;Int. J. Inorg. Mater.
+International Journal of Marine Energy;Int. J. Mar. Energy;;
 International Journal of Mass Spectrometry;Int. J. Mass Spectrom.
 International Journal of Mass Spectrometry and Ion Processes;Int. J. Mass Spectrom. Ion Processes
 International Journal of Materials Research;Int. J. Mater. Res.
+International Journal of Metrology and Quality Engineering;Int.J. Metrol. Qual. Eng.;;
 International Journal of Mineral Processing;Int. J. Miner. Process.
 International Journal of Modern Physics B;Int. J. Mod Phys B
 International Journal of Multiphase Flow;Int. J. Multiphase Flow
 International Journal of Multiphysics;Int. J. Multiphys.
 International Journal of Nanoscience;Int. J. Nanosci.
 International Journal of Non-Equilibrium Processing;Int. J. Non-Equilib. Process.
+International Journal of Nonlinear Modelling in Science and Engineering;Int. J. Nonlinear Modell. Sci. Eng.;;
 International Journal of Nonlineare Modelling in Science and Engineering;Int. J. Nonlinear Modell. Sci. Eng.
 International Journal of Oncology;Int. J. Oncol.
-International Journal of Peptide and Protein Research;Int. J. Pept. Protein Res.
-International Journal of Peptide Research and Therapeutics;Int. J. Pept. Res. Ther.
-International Journal of Pharmaceutics;Int. J. Pharm.
-International Journal of Phytoremediation;Int. J. Phytorem.
 International Journal of PIXE;Int. J. PIXE
+International Journal of Paleopathology;Int. J. Paleopathol.;;
+International Journal of Peptide Research and Therapeutics;Int. J. Pept. Res. Ther.
+International Journal of Peptide and Protein Research;Int. J. Pept. Protein Res.
+International Journal of Pharmaceutics;Int. J. Pharm.
+International Journal of Pharmacy and Pharmaceutical Sciences;Int. J. Pharm. Pharm. Sci.;;
+International Journal of Phytoremediation;Int. J. Phytorem.
 International Journal of Plasticity;Int. J. Plast.
 International Journal of Polymer Analysis and Characterization;Int. J. Polym. Anal. Charact.
 International Journal of Polymeric Materials;Int. J. Polym. Mater.
@@ -2106,7 +2508,10 @@ International Journal of Radiation Biology;Int. J. Radiat. Biol.
 International Journal of Radiation Oncology, Biology, Physics;Int. J. Radiat. Oncol., Biol., Phys.
 International Journal of Refractory Metals & Hard Materials;Int. J. Refract. Met. Hard Mater.
 International Journal of Self-Propagating High-Temperature Synthesis;Int. J. Self-Propag. High-Temp Synth.
+International Journal of Streel Structures;Int. J. Steel Struct.;;
+International Journal of Sustainable Build Environment;Int. J. Sustainable Built Environ.;;
 International Journal of Thermophysics;Int. J. Thermophys.
+International Journal of Transportation Science and Technology;Int. J. Transp. Sci. Technol.;;
 International Journal of Tropical Insect Science;Int. J. Trop. Insect Sci.
 International Lichenological Newsletter;Int. Lichenol. Newsl.
 International Materials Reviews;Int. Mater. Rev.
@@ -2118,24 +2523,26 @@ International SAMPE Symposium and Exhibition;Int. SAMPE Symp. Exhib.
 International Tree Crops Journal;Int. Tree Crops J.
 Internationale Mitteilungen für Bodenkunde;Int. Mitt. Bodenkd.
 Internet Computing;Internet Comput.
+Internet Interventions;Internet Interventions;;
 Internet Journal of Chemistry;Internet J. Chem.
 Internet Journal of Vibrational Spectroscopy;Internet J. Vib. Spectro.
 Inverse Problems;Inverse Prob.
+Inverse Problems in Engineering;Inverse Prob. Eng.;;
 Investigational New Drugs;Invest. New Drugs
+Investigative Ophthalmology & Visual Science;Invest. Ophthalmol. Visual Sci.;;
 Inzhenerno-Fizicheskii Zhurnal;Inzh.-Fiz. Zh.
 Inzynieria Chemiczna i Procesowa;Inz. Chem. Procesowa
 Ion Exchange and Solvent Extraction;Ion Exch. Solvent Extr.
 Ionics;Ionics
-IOWA Agricultural Experiment Station Research Bulletin;IOWA Agric. Exp. Stn. Res. Bull.
 Ironmaking & Steelmaking;Ironmaking Steelmaking
-ISIJ International;ISIJ Int.
+Irrigation and Drainage;Irrig. Drain.;;
+Island Arc;Isl. Arc;;
 Isotopenpraxis;Isotopenpraxis
 Isotopes in Environmental and Health Studies;Isot. Environ. Health Stud.
 Israel Journal of Chemistry;Isr. J. Chem.
 Italia forestale e montana, L’;Ital. for. mont.
 Italian Journal of Biochemistry;Ital. J. Biochem.
-ITC-Journal;ITC-J.
-IUBMB Life;IUBMB Life
+Italian Journal of Geosciences;Ital. J. Geosci.;;
 Iyakuhin Kenkyu;Iyakuhin Kenkyu
 Izmeritel'naya Tekhnika;Izmer. Tekh.
 Izvestiya Akademii Nauk Gruzii, Seriya Khimicheskaya;Izv. Akad. Nauk Gruz. SSR, Ser. Khim.
@@ -2148,22 +2555,34 @@ Izvestiya Vysshikh Uchebnykh Zavedenii, Chernaya Metallurgiya;Izv. Vyssh. Uchebn
 Izvestiya Vysshikh Uchebnykh Zavedenii, Fizika;Izv. Vyssh. Uchebn. Zaved., Fiz.
 Izvestiya Vysshikh Uchebnykh Zavedenii, Khimiya i Khimicheskaya Tekhnologiya;Izv. Vyssh. Uchebn. Zaved., Khim. Khim. Tekhnol.
 Izvestiya Vysshikh Uchebnykh Zavedenii, Tsvetnaya Metallurgiya;Izv. Vyssh. Uchebn. Zaved., Tsvetn. Metall.
+JAMA, the Journal of the American Medical Association;JAMA, J. Am. Med. Assoc.
+JBIC, Journal of Biological Inorganic Chemistry;JBIC, J. Biol. Inorg. Chem.
+JCP: Biochemical Physics;JCP: Biochem. Phys.;;
+JCT Research;JCT Res.
+JETP Letters;JETP Lett.
+JJournal of Agricultural Safety and Health;J. Agric. Saf. Health;;
+JMM Case Reports;JMM Case Rep.;;
+JOM Journal of the Minerals Metals and Materials Society;JOM
+JOT Journal für Oberflaechentechnik;JOT, J. Oberflaechentech.
+JPC Journal of Planar Chromatography Modern TLC;JPC J. Planar Chromatogr. - Mod. TLC
+JSME International Journal Series A: Mechanics and Material Engineering;JSME Int J., Ser. A
+JSME International Journal Series B: Fluids and Thermal Engineering;JSME Int J., Ser. B
+JSME International Journal Series C: Mechanical Systems Machine Elements and Manufacturing;JSME Int J., Ser. C
 Jagd und Natur;Jagd Nat.
+Jahrbuch Schweizerische Akademie der Naturwissenschaften;Jahrb. Schweiz. Akad. Nat.wiss.
 Jahrbuch der Schweizerischen Gesellschaft für Ur- und Frühgeschichte;Jahrb. Schweiz. Ges. Ur- Frühgesch.
 Jahrbuch der Schweizerischen naturforschenden Gesellschaft;Jahrb. Schweiz. nat.forsch. Ges.
-Jahrbuch der schweizerischen Wald- und Holzwirtschaft;Jahrb. schweiz. Wald- Holzwirtsch.
 Jahrbuch der St. Gallischen Naturwissenschaftlichen Gesellschaft;Jahrb. St. Gallische Nat.wiss. Ges.
+Jahrbuch der schweizerischen Wald- und Holzwirtschaft;Jahrb. schweiz. Wald- Holzwirtsch.
 Jahrbuch des Oberaargaus;Jahrb. Oberaargau
 Jahrbuch des Schweizerischen Wasserwirtschaftsverbandes;Jahrb. Schweiz. Wasserwirtschafts-verb.
 Jahrbuch des Vereins zum Schutze der Alpenpflanzen und -Tiere;Jahrb. Ver. Schutz Alp.pflanzen -Tiere
 Jahrbuch für Naturschutz und Landschaftspflege;Jahrb. Nat.schutz Landsch.pfl.
-Jahrbuch Schweizerische Akademie der Naturwissenschaften;Jahrb. Schweiz. Akad. Nat.wiss.
 Jahrbuch vom Thuner- und Brienzersee;Jahrb. Thuner- Brienzersee
 Jahrbuch vom Zürichsee;Jahrb. Zür.see
-Jahresbericht der Naturforschenden Gesellschaft Graubünden;Jahresber. Nat.forsch. Ges. Graubünden
 Jahresbericht Lignum;Jahresber. Lignum
+Jahresbericht der Naturforschenden Gesellschaft Graubünden;Jahresber. Nat.forsch. Ges. Graubünden
 Jahreshefte des Vereins für vaterländische Naturkunde in Württemberg;Jahresh. Ver. vaterl. Nat.kd. Württ.
-JAMA, the Journal of the American Medical Association;JAMA, J. Am. Med. Assoc.
 Japan Society of Mechanical Engineers International Journal Series A: Solid Mechanics and Material Engineering;J. Soc. Mech. Eng. Int. J. Ser.A:
 Japan Society of Mechanical Engineers International Journal Series B: Fluids and Thermal Engineering;J. Soc. Mech. Eng. Int. J. Ser.B:
 Japan Society of Mechanical Engineers International Journal Series C: Mechanical Systems, Machine Elements and Manufacturing;J. Soc. Mech. Eng. Int. J. Ser.C:
@@ -2173,58 +2592,65 @@ Japanese Journal of Applied Physics, Part 2: Letters & Express Letters;Jpn. J. A
 Japanese Journal of Applied Physics, Part I: Regular Papers and Short Notes;Jpn. J. Appl. Phys., Part 1
 Japanese Journal of Applied Physics, Part II: Letters;Jpn. J. Appl. Phys., Part 2
 Japanese Journal of Cancer Research;Jpn. J. Cancer Res.
+Japanese Journal of Forensic Toxicology;Jpn. J. Forensic Toxicol.;;
 Japanese Journal of Pharmacology;Jpn. J. Pharmacol.
 Japanese Journal of toxicology and Environment health;Jpn. J. Toxicol. Environ. Health
-JBIC, Journal of Biological Inorganic Chemistry;JBIC, J. Biol. Inorg. Chem.
-JCT Research;JCT Res.
-JETP Letters;JETP Lett.
 Jiegou Huaxue;Jiegou Huaxue
 Jinshu Rechuli;Jinshu Rechuli
 Jinshu Xuebao;Jinshu Xuebao
 Jisuanji Yu Yingyong Huaxue;Jisuanji Yu Yingyong Huaxue
-JOM Journal of the Minerals Metals and Materials Society;JOM
+JoVE Chemistry;JoVE Chem.;;
 Jordan Journal of Chemistry;Jordan J. Chem.
-JOT Journal für Oberflaechentechnik;JOT, J. Oberflaechentech.
 Jounal of Wildlife Research;J. Wildl. Res.
 Journal - American Water Works Association;J. - Am. Water Works Assoc.
 Journal Canadien des Sciences de la Terre;J. Can. Sci. Terre
 Journal de Chimie Physique et de Physico-Chimie Biologique;J. Chim. Phys. Phys.- Chim. Biol.
-Journal de la Societa de Biologie;J. Soc. Biol.
-Journal de la Societe Algerienne de Chimie;J. Soc. Alg. Chim.
-Journal de la Societe Chimique de Tunisie;J. Soc. Chim. Tunis.
-Journal de la Societe Ouest Africaine de Chimie;J. Soc. Ouest Afr. Chim.
 Journal de Pharmacie de Belgique;J. Pharm. Belg.
 Journal de Physique I;J. Phys. I
 Journal de Physique II;J. Phys. II
 Journal de Physique III;J. Phys. III
 Journal de Physique IV;J. Phys. IV
+Journal de la Societa de Biologie;J. Soc. Biol.
+Journal de la Societe Algerienne de Chimie;J. Soc. Alg. Chim.
+Journal de la Societe Chimique de Tunisie;J. Soc. Chim. Tunis.
+Journal de la Societe Ouest Africaine de Chimie;J. Soc. Ouest Afr. Chim.
+Journal for ImmunoTherapy of Cancer;J. ImmunoTher. Cancer;;
 Journal forestier suisse;J. for. suisse
+Journal fur Klinische Endokrinologie und Stoffwechsel;J. Klin. Endokrinolog. Stoffwechsel;;
 Journal für Ornithologie;J. Ornithol.
 Journal für Praktische Chemie;J. Prakt. Chem.
 Journal für Verbraucherschutz und Lebensmittelsicherheit;J. Verbraucherschutz Lebensmittelsicherh.
+Journal of AOAC International;J. AOAC Int.
+Journal of Addiction Medicine;J. Addict. Med.;;
+Journal of Addiction Research & Therapy;J. Addict. Res. Ther.;;
 Journal of Adhesion;J. Adhes.
 Journal of Adhesion Science and Technology;J. Adhes. Sci. Technol.
 Journal of Advanced Materials;J. Adv. Mater.
+Journal of Advanced Microscopy Research;J. Adv. Microsc. Res.;;
+Journal of Advanced Pharmaceutical Technology & Research;J. Adv. Pharm. Technol. Res.;;
 Journal of Advances in Chemical Physics;J. Adv. Chem. Phys.
+Journal of Advances in Modeling Earth Systems;J. Adv. Model. Earth Syst.;;
 Journal of Aerosol Science;J. Aerosol Sci.
-Journal of Agricultural and Food Chemistry;J. Agric. Food Chem.
 Journal of Agricultural Research;J. Agric. Res.
 Journal of Agricultural Science;J. Agric. Sci.
+Journal of Agricultural and Food Chemistry;J. Agric. Food Chem.
+Journal of Agriculture, Food Systems, and Community Development;J. Agric. Food Sys. Community Dev.;;
 Journal of Alloys and Compounds;J. Alloys Compd.
-Journal of Analytical and Applied Pyrolysis;J. Anal. Appl. Pyrolysis
 Journal of Analytical Atomic Spectrometry;J. Anal. At. Spectrom.
 Journal of Analytical Chemistry;J. Anal. Chem.
+Journal of Analytical Science and Technology;J. Anal. Sci. Technol.;;
 Journal of Analytical Toxicology;J. Anal. Toxicol.
+Journal of Analytical and Applied Pyrolysis;J. Anal. Appl. Pyrolysis
 Journal of Anatomy;J. Anat.
 Journal of Animal Ecology;J. Anim. Ecol.
-Journal of Animal Ecology;J. Anim. Ecol.
-Journal of Animal Science (Savoy, IL, United States);J. Anim. Sci. (Savoy, IL, U. S.)
 Journal of Animal Science;J. Anim. Sci.
+Journal of Animal Science (Savoy, IL, United States);J. Anim. Sci. (Savoy, IL, U. S.)
+Journal of Animal Science and Biotechnology;J. Anim. Sci. Biotechnol.;;
 Journal of Antibiotics;J. Antibiot.
 Journal of Antimicrobial Chemotherapy;J. Antimicrob. Chemother.
-Journal of AOAC International;J. AOAC Int.
 Journal of Appled Electrochemistry;J. Appl. Electrochem.
 Journal of Applied Animal Welfare Science;J. Appl. Anim. Welfare Sci.
+Journal of Applied Aquaculture;J. Appl. Aquacult.;;
 Journal of Applied Bacteriology;J. Appl. Bacteriol.
 Journal of Applied Biological Chemistry;J. Appl. Biol. Chem.
 Journal of Applied Biomaterials;J. Appl. Biomater.
@@ -2238,10 +2664,17 @@ Journal of Applied Physics;J. Appl. Phys.
 Journal of Applied Physiology;J. Appl. Physiol.
 Journal of Applied Polymer Science;J. Appl. Polym. Sci.
 Journal of Applied Polymer Science: Applied Polymer Symposium;J. Appl. Polym. Sci.: Appl. Polym. Symp.
+Journal of Applied Research and Technology;J. Appl. Res. Technol.;;
+Journal of Applied Research on Medicinal and Aromatic Plants;J. Appl. Res. Med. Aromat. Plants;;
 Journal of Applied Spectroscopy;J. Appl. Spectrosc.
 Journal of Applied Toxicology;J. Appl. Toxicol.
 Journal of Archaeological Science;J. Archaeol. Sci.
+Journal of Archaeological Science: Reports;J. Archaeolog. Sci.: Rep.;;
+Journal of Asia-Pacific Biodiversity;J. Asia-Pac. Biodivers.;;
+Journal of Asian Ceramic Societies;J. Asian Ceram. Soc.;;
 Journal of Asian Natural Products Research;J. Asian Nat. Prod. Res.
+Journal of Assistive, Rehabilitative and Therapeutic Technologies;J. Assistive Rehabil. Ther. Technol.;;
+Journal of Astronomical Telescopes, Instruments, and Systems;J. Astron. Telesc. Instrum. Syst.;;
 Journal of Atmospheric Chemistry;J. Atmos. Chem.
 Journal of Automated Methods & Management in Chemistry;J. Autom. Methods Manage. Chem.
 Journal of Automatic Chemistry;J. Autom. Chem.
@@ -2251,24 +2684,28 @@ Journal of Basic Microbiology;J. Basic Microbiol.
 Journal of Bioactive and Bocompatible Polymers;J. Bioact. Compat. Polym.
 Journal of Biochemical and Biophysical Methods;J. Biochem. Biophys. Methods
 Journal of Biochemical and Molecular Toxicology;J. Biochem. Mol. Toxicol.
-Journal of Biochemistry (Tokyo, Japan);J. Biochem. (Tokyo, Jpn.)
 Journal of Biochemistry;J. Biochem.
+Journal of Biochemistry (Tokyo, Japan);J. Biochem. (Tokyo, Jpn.)
 Journal of Biochemistry and Molecular Biology;J. Biochem. Mol. Biol.
 Journal of Bioenergetics and Biomembranes;J. Bioenerg. Biomembr.
 Journal of Bioengineering;J. Bioeng.
+Journal of Bioequivalence & Bioavailability;J. Bioequivalence Bioavailability;;
 Journal of Biogeography;J. Biogeogr.
 Journal of Biological Chemistry;J. Biol. Chem.
 Journal of Biological Inorganic Chemistry;J. Biol. Inorg. Chem.
+Journal of Biological Research-Thessaloniki;J. Biol. Res. Thessaloniki;;
 Journal of Bioluminescence and Chemiluminescence;J. Biolumin. Chemilumin.
 Journal of Biomaterials Applications;J. Biomater. Appl.
 Journal of Biomaterials Science, Polymer Edition;J. Biomater. Sci., Polym. Ed.
 Journal of Biomechanical Engineering;J. Biomech. Eng.
 Journal of Biomedial Materials Research;J. Biomed. Mater. Res.
+Journal of Biomedial Materials ResearchPart A;J. Biomed. Mater. Res. Part A;;
 Journal of Biomedical Engineering;J. Biomed. Eng.
 Journal of Biomedical Materials Research, Part A;J. Biomed. Mater. Res., Part A
 Journal of Biomedical Materials Research, Part B: Applied Biomaterials;J. Biomed. Mater. Res., Part B
 Journal of Biomedical Nanotechnology;J. Biomed. Nanotechnol.
 Journal of Biomolecular NMR;J. Biomol. NMR
+Journal of Biomolecular Structure & Dynamics;J. Biomol. Struct. Dyn.;;
 Journal of Biomolecular Structure and Dynamics;J. Biomol. Struct. Dyn.
 Journal of Bioscience and Bioengineering;J. Biosci. Bioeng.
 Journal of Biosciences;J. Biosci.
@@ -2277,8 +2714,10 @@ Journal of Bone and Mineral Research;J. Bone Miner. Res.
 Journal of Breath Research;J. Breath Res.
 Journal of Canadian Petroleum Technology;J. Can. Pet. Technol.
 Journal of Cancer Molecules;J. Cancer Mol.
+Journal of Cancer Research and Therapeutics;J. Cancer Res. Ther.;;
 Journal of Capillary Electrophoresis and Microchip Technology;J. Capillary Electrophor. Microchip Technol.
 Journal of Carbohydrate Chemistry;J. Carbohydr. Chem.
+Journal of Cardiovascular Computed Tomography;J. Cardiovasc. Comput. Tomogr.;;
 Journal of Cardiovascular Pharmacology;J. Cardiovasc. Pharmacol.
 Journal of Catalysis;J. Catal.
 Journal of Cell Biology;J. Cell Biol.
@@ -2301,36 +2740,45 @@ Journal of Chemical Sciences (Bangalore, India);J. Chem. Sci. (Bangalore, India)
 Journal of Chemical Technology and Biotechnology;J. Chem. Technol. Biotechnol.
 Journal of Chemical Theory and Computation;J. Chem. Theory Comput.
 Journal of Chemical Thermodynamics;J. Chem. Thermodyn.
+Journal of Cheminformatics;J. Cheminf.;;
 Journal of Chemometrics;J. Chemom.
 Journal of Chromatographic Science;J. Chromatogr. Sci.
 Journal of Chromatography;J. Chromatogr.
 Journal of Chromatography, A;J. Chromatogr., A
 Journal of Chromatography, B: Analytical Technologies in the Biomedical and Life Sciences;J. Chromatogr., B: Anal. Technol. Biomed. Life Sci.
+Journal of Circadian Rhythms;J. Circadian Rhythms;;
 Journal of Climate;J. Clim.
 Journal of Climate and Applied Meteorology;J. Clim. Appl. Meteorol.
+Journal of Clinical Bioinformatics;J. Clin. Bioinf.;;
 Journal of Clinical Endocrinology and Metabolism;J. Clin. Endocrinol. Metab.
+Journal of Clinical Imaging Science;J. Clin. Imaging Sci.;;
 Journal of Clinical Investigation;J. Clin. Invest.
+Journal of Clinical Medicine Research;J. Clin. Med. Res.;;
 Journal of Clinical Microbiology;J. Clin. Microbiol.
+Journal of Clinical and Experimental Dentistry;J. Clin. Exp. Dent.;;
 Journal of Cluster Science;J. Cluster Sci.
 Journal of Coastal Research;J. Coast. Res.
 Journal of Coatings Technology;J. Coat. Technol.
 Journal of Coatings Technology and Research;J. Coat. Technol. Res.
 Journal of Colloid and Interface Science;J. Colloid Interface Sci.
 Journal of Combinatorial Chemistry;J. Comb. Chem.
-Journal of Comparative Neurology;J. Comp. Neurol.
+Journal of Communications and Networks;J. Commun. Networks;;
+Journal of Comparative Effectiveness Research;J. Comp. Eff. Res.;;
 Journal of Comparative Neurology;J. Comp. Neurol.
 Journal of Comparative Physiology;J. Comp. Physiol.
 Journal of Composite Materials;J. Compos. Mater.
 Journal of Composites Technology and Research;J. Compos. Tech. Res.
+Journal of Computational Biology;J. Comput. Biol.
+Journal of Computational Chemistry;J. Comput. Chem.
+Journal of Computational Design and Engineering;J. Comput. Des. Eng.;;
+Journal of Computational Physics;J. Comput. Phys.
 Journal of Computational and Graphical Statistics;J. Comput. Graph. Stat.
 Journal of Computational and Nonlinear Dynamics;J. Comput. Nonlinear Dyn.
 Journal of Computational and Theoretical Nanoscience;J. Comput. Theor. Nanosci.
-Journal of Computational Biology;J. Comput. Biol.
-Journal of Computational Chemistry;J. Comput. Chem.
-Journal of Computational Physics;J. Comput. Phys.
 Journal of Computer Chemistry, Japan;J. Comput. Chem., Jpn.
 Journal of Computer-Aided Materials Design;J. Comput. Aided Mater. Des.
 Journal of Computer-Aided Molecular Design;J. Comput.-Aided Mol. Des.
+Journal of Computing Science and Engineering;J. Comput. Sci. Eng.;;
 Journal of Contaminant Hydrology;J. Contam. Hydrol.
 Journal of Controlled Release;J. Controlled Release
 Journal of Coordination Chemistry;J. Coord. Chem.
@@ -2343,18 +2791,21 @@ Journal of Dispersion Science and Technology;J. Dispersion Sci. Technol.
 Journal of Drug Targeting;J. Drug Targeting
 Journal of Ecology;J. Ecol.
 Journal of Economic Entomology;J. Econ. Entomol.
-Journal of Economic Entomology;J. Econ. Entomol.
 Journal of Economic Geography;J. Econ. Geogr.
 Journal of Elastomers and Plastics;J. Elastomers Plast.
+Journal of Electrical Engineering and Technology;J. Electr. Eng. Technol.;;
+Journal of Electrical Systems and Information Technology;J. Electr. Syst. Inf. Technol.;;
 Journal of Electroanalytical Chemistry;J. Electroanal. Chem.
 Journal of Electroceramics;J. Electroceram.
 Journal of Electron Microscopy;J. Electron Microsc.
 Journal of Electron Spectroscopy and Related Phenomena;J. Electron Spectrosc. Relat. Phenom.
 Journal of Electronic Materials;J. Electron. Mater.
+Journal of Electronic Science and Technology;J. Electron. Sci. Technol.;;
 Journal of Endocrinology;J. Endocrinol.
 Journal of Endotoxin Research;J. Endotoxin Res.
 Journal of Energetic Materials;J. Energ. Mater.
 Journal of Engineered Fibers and Fabrics;J. Eng. Fibers Fabr.
+Journal of Engineering;J. Eng.;;
 Journal of Engineering Materials and Technology;J. Eng. Mater. Technol.
 Journal of Environment Biology;J. Environ. Biol.
 Journal of Environment Health;J. Environ. Health
@@ -2364,8 +2815,8 @@ Journal of Environment Radioactivity;J. Environ. Radioact.
 Journal of Environment Science and Health, Part A Environmental Science;J. Environ. Sci. Health., Part A
 Journal of Environment Science and Health, Part B Pesticides;J. Environ. Sci. Health., Part B
 Journal of Environmental Education;J. Environ. Educ.
-Journal of Environmental Engineering (Reston, VA, United States);J. Environ. Eng. (Reston, VA, U. S.)
 Journal of Environmental Engineering;J. Environ. Eng.
+Journal of Environmental Engineering (Reston, VA, United States);J. Environ. Eng. (Reston, VA, U. S.)
 Journal of Environmental Management;J. Environ. Manage.
 Journal of Environmental Monitoring;J. Environ. Monit.
 Journal of Environmental Psychology;J. Environ. Psychol.
@@ -2375,20 +2826,25 @@ Journal of Environmental Science & Engineering;J. Environ. Sci. Eng.
 Journal of Environmental Science and Health, Part A: Environmental Science and Engineering;J. Environ. Sci. Health, Part A
 Journal of Environmental Science and Health, Part A: Toxic/Hazardous Substances & Environmental Engineering;J. Environ. Sci. Health, Part A: Toxic/Hazard. Subst. Environ. Eng.
 Journal of Environmental Science and Health, Part B: Pesticides, Food Contaminants, and Agricultural Wastes;J. Environ. Sci. Health, Part B
+Journal of Environmental Sciences;J. Environ. Sci.;;
+Journal of Environmental Solutions for Oil, Gas, and Mining;J. Environ. Solutions Oil Gas Min.;;
 Journal of Enzyme Inhibition;J. Enzyme Inhib.
 Journal of Enzyme Inhibition and Medicinal Chemistry;J. Enzyme Inhib. Med. Chem.
 Journal of Ethnopharmacology;J. Ethnopharmacol.
 Journal of Eukaryotic Microbiology;J. Eukaryot. Microbiol.
-Journal of Experimental and Theoretical Physics;J. Exp. Theor. Phys.
+Journal of Evolutionary Biochemistry and Physiology;J. Evol. Biochem. Physiol.;;
+Journal of Experimental & Clinical Cancer Research;J. Exp. Clin. Cancer Res.;;
 Journal of Experimental Animal Science;J. Exp. Anim. Sci.
-Journal of Experimental Biology;J. Exp. Biol.
 Journal of Experimental Biology;J. Exp. Biol.
 Journal of Experimental Botany;J. Exp. Bot.
 Journal of Experimental Medicine;J. Exp. Med.
 Journal of Experimental Nanoscience;J. Exp. Nanosci.
 Journal of Experimental Zoology;J. Exp. Zool.
+Journal of Experimental and Theoretical Physics;J. Exp. Theor. Phys.
 Journal of Exposure Analysis and Environment Epidemiology;J. Exposure Anal. Environ. Epidemiol.
+Journal of Facade Design and Engineering;J. Facade Des. Eng.;;
 Journal of Fermentation and Bioengineering;J. Ferment. Bioeng.
+Journal of Fiber Bioengineering and Informatics;J. Fiber Bioeng. Inf.;;
 Journal of Field Archaeology;J. Field Archaeol.
 Journal of Fire Sciences;J. Fire Sci.
 Journal of Fish Biology;J. Fish Biol.
@@ -2404,24 +2860,29 @@ Journal of Food Processing and Preservation;J. Food Process. Preserv.
 Journal of Food Protection;J. Food Prot.
 Journal of Food Quality;J. Food Qual.
 Journal of Food Science;J. Food Sci.
-Journal of Food Science and Technology;J. Food Sci. Technol.
 Journal of Food Science Education;J. Food Sci. Educ.
+Journal of Food Science and Technology;J. Food Sci. Technol.
 Journal of Food Technology;J. Food Technol.
+Journal of Food and Drug Analysis;J. Food Drug Anal.;;
+Journal of Food, Agriculture & Environment;J. Food Agric. Environ.;;
 Journal of Food, Agriculture and Environment;J. Food, Agric. Environ.
+Journal of Forensic Dental Sciences;J. Forensic Dent. Sci.;;
 Journal of Forensic Medicine;J. Forensic Med.
 Journal of Forensic Medicine and Toxicology;J. Forensic Med. Toxicol.
+Journal of Forensic Radiology and Imaging;J. Forensic Radiol. Imaging;;
 Journal of Forensic Science;J. Forensic Sci.
+Journal of Forensic and Legal Medicine;J. Forensic Legal Med.;;
 Journal of Forestry;J. For.
+Journal of Freshwater Ecology;J. Freshwater Ecol.;;
 Journal of Fusion Energy;J. Fusion Energy
-Journal of General and Applied Microbiology;J. Gen. Appl. Microbiol.
 Journal of General Microbiology;J. Gen. Microbiol.
 Journal of General Physiology;J. Gen. Physiol.
 Journal of General Virology;J. Gen. Virol.
+Journal of General and Applied Microbiology;J. Gen. Appl. Microbiol.
 Journal of Genome Science and Technology;J. Genome Sci. Technol.
 Journal of Geochemical Exploration;J. Geochem. Explor.
 Journal of Geological Education;J. Geol. Educ.
 Journal of Geology;J. Geol.
-Journal of Geophysical Research;J. Geophys. Res.
 Journal of Geophysical Research;J. Geophys. Res.
 Journal of Geophysical Research, A: Space Physics;J. Geophys. Res., A: Space Phys.
 Journal of Geophysical Research, B: Solid Earth;J. Geophys. Res., B: Solid Earth
@@ -2440,15 +2901,21 @@ Journal of Geophysical Research, [Space Physics];J. Geophys. Res. [Space Phys.]
 Journal of Geophysics;J. Geophys.
 Journal of Geophysics and Engineering;J. Geophys. Eng.
 Journal of Geotechnical and Geoenvironmental Engineering;J. Geotech. Geoenviron. Eng.
+Journal of Ginseng Research;J. Ginseng Res.;;
 Journal of Glaciology;J. Glaciol.
+Journal of Hard Tissue Biology;J. Hard Tissue Biol.;;
 Journal of Hazardous Materials;J. Hazard. Mater.
 Journal of Heat Transfer;J. Heat Transfer
 Journal of Heredity;J. Hered.
 Journal of Heterocyclic Chemistry;J. Heterocycl. Chem.
+Journal of High Energy Astrophysics;J. High Energy Astrophys.;;
 Journal of High Energy Physics;J. High Energy Phys.
 Journal of High Resolution Chromatography;J. High. Resolut. Chromatogr.
 Journal of Histochemistry and Cytochemistry;J. Histochem. Cytochem.
+Journal of Holography and Speckle;J. Hologr. Speckle;;
 Journal of Hydrology;J. Hydrol.
+Journal of Hydrology: Regional Studies;J. Hydrol.: Reg. Stud.;;
+Journal of Hydrometeorology;J. Hydrometeorol.;;
 Journal of Hypertension;J. Hypertens.
 Journal of Imaging Science and Technology;J. Imaging Sci. Technol.
 Journal of Immunoassay & Immunochemistry;J. Immunoassay Immunochem.
@@ -2456,22 +2923,30 @@ Journal of Immunological Methods;J. Immunol. Methods
 Journal of Immunology;J. Immunol.
 Journal of Inclusion Phenomena and Macrocyclic Chemistry;J. Inclusion Phenom. Macrocyclic Chem.
 Journal of Inclusion Phenomena and Molecular Recognition in Chemistry;J. Inclusion Phenom. Mol. Recognit. Chem.
-Journal of Industrial and Engineering Chemistry (Seoul, Republic of Korea);J. Ind. Eng. Chem. (Seoul, Repub. Korea)
-Journal of Industrial Microbiology & Biotechnology;J. Ind. Microbiol. Biotechnol.
 Journal of Industrial Microbiology;J. Ind. Microbiol.
+Journal of Industrial Microbiology & Biotechnology;J. Ind. Microbiol. Biotechnol.
+Journal of Industrial and Engineering Chemistry (Seoul, Republic of Korea);J. Ind. Eng. Chem. (Seoul, Repub. Korea)
 Journal of Infectious Diseases;J. Infect. Dis.
+Journal of Information Processing Systems;J. Inf. Process. Syst.;;
+Journal of Innate Immunity;J. Innate Immun.;;
+Journal of Inorganic Biochemistry;J. Inorg. Biochem.
 Journal of Inorganic and Nuclear Chemistry;J. Inorg. Nucl. Chem.
 Journal of Inorganic and Organometallic Polymers;J. Inorg. Organomet. Polym.
 Journal of Inorganic and Organometallic Polymers and Materials;J. Inorg. Organomet. Polym. Mater.
-Journal of Inorganic Biochemistry;J. Inorg. Biochem.
 Journal of Insect Physiology;J. Insect Physiol.
+Journal of Insects as Food and Feed;J. Insects Food Feed;;
 Journal of Institute of Chemists (India);J. Inst. Chem.
 Journal of Instrumentation;J. Instrum.
 Journal of Intelligent Material Systems and Structures;J. Intell. Mater. Syst. Struct.
+Journal of Intelligent Transportation Systems: Technology, Planning, and Operations;J. Intell. Transp. Syst. Technol. Plann. Oper.;;
 Journal of Interferon & Cytokine Research;J. Interferon Cytokine Res.
 Journal of Interferon Research;J. Interferon Res.
 Journal of Investigative Dermatology;J. Invest. Dermatol.
+Journal of Investigative Medicine High Impact Case Reports;J. Invest. Med. High Impact Case Rep.;;
+Journal of Investigative and Clinical Dentistry;J. Invest. Clin. Dent.;;
 Journal of Japanese Botany;J. Jpn. Bot.
+Journal of Korean Institute of Metals and Materials;J. Korean Inst. Met. Mater.;;
+Journal of Labelled Compounds & Radiopharmaceuticals;J. Labelled Compd. Radiopharm.;;
 Journal of Labelled Compounds and Radiopharmaceuticals;J. Labelled Compd. Radiopharm.
 Journal of Laboratory and Clinical Medicine;J. Lab. Clin. Med.
 Journal of Leukocyte Biology;J. Leukocyte Biol.
@@ -2480,9 +2955,10 @@ Journal of Lipid Mediators;J. Lipid Mediators
 Journal of Lipid Mediators and Cell Signalling;J. Lipid Mediat. Cell Signal.
 Journal of Lipid Research;J. Lipid Res.
 Journal of Lipid Science and Technology;J. Lipid Sci. Technol.
-Journal of Liquid Chromatography & Related Technologies;J. Liq. Chromatogr. Relat. Technol.
 Journal of Liquid Chromatography;J. Liq. Chromatogr.
+Journal of Liquid Chromatography & Related Technologies;J. Liq. Chromatogr. Relat. Technol.
 Journal of Loss Prevention in the Process Industries;J. Loss Prev. Process Ind.
+Journal of Low Power Electronics;J. Low Power Electron.;;
 Journal of Low Temperature Physics;J. Low Temp. Phys.
 Journal of Luminescence;J. Lumin.
 Journal of Macromolecular Science - Reviews in Macromolecular Chemistry and Physics;J. Macromol. Sci., Rev. Macromol. Chem. Phys.
@@ -2490,7 +2966,6 @@ Journal of Macromolecular Science, Part A: Pure and Applied Chemistry;J. Macromo
 Journal of Macromolecular Science, Part B: Physics;J. Macromol. Sci., Part B: Phys.
 Journal of Macromolecular Science, Part C: Polymer Reviews;J. Macromol. Sci., Part C: Polym. Rev.
 Journal of Macromolecular Science, Physics;J. Macromol. Sci., Phys.
-Journal of Macromolecular Science, Polymer Reviews;J. Macromol. Sci., Polym. Rev.
 Journal of Macromolecular Science, Polymer Reviews;J. Macromol. Sci., Polym. Rev.
 Journal of Macromolecular Science, Pure and Applied Chemistry;J. Macromol. Sci., Pure Appl. Chem.
 Journal of Magnetic Resonance;J. Magn. Reson.
@@ -2501,36 +2976,44 @@ Journal of Mammalogy;J. Mammal.
 Journal of Mass Spectrometry;J. Mass Spectrom.
 Journal of Material Cycles and Waste Management;J. Mater. Cycles Waste Manage.
 Journal of Materials Chemistry;J. Mater. Chem.
+Journal of Materials Chemistry A;J. Mater. Chem.A;;
+Journal of Materials Chemistry B;J. Mater. Chem. B;;
+Journal of Materials Chemistry C;J. Mater. Chem. C;;
 Journal of Materials Engineering and Performance;J. Mater. Eng. Perform.
-Journal of Materials in Civil Engineering;J. Mater. Civ. Eng.
-Journal of Materials Processing and Manufacturing Science;J. Mater. Process. Manuf. Sci.
 Journal of Materials Processing Technology;J. Mater. Process. Technol.
+Journal of Materials Processing and Manufacturing Science;J. Mater. Process. Manuf. Sci.
 Journal of Materials Research;J. Mater. Res.
 Journal of Materials Science;J. Mater. Sci.
-Journal of Materials Science and Technology;J. Mater. Sci. Technol.
-Journal of Materials Science Letters;J. Mater. Sci. Lett.
 Journal of Materials Science Letters;J. Mater. Sci. Lett.
 Journal of Materials Science Materials in Medicine;J. Mater. Sci. - Mater. Med.
+Journal of Materials Science and Engineering;J. Mater. Sci. Eng;;
+Journal of Materials Science and Technology;J. Mater. Sci. Technol.
 Journal of Materials Science: Materials in Electronics;J. Mater. Sci.: Mater. Electron.
 Journal of Materials Science: Materials in Medicine;J. Mater. Sci.: Mater. Med.
 Journal of Materials Synthesis and Processing;J. Mater. Synth. Process.
+Journal of Materials in Civil Engineering;J. Mater. Civ. Eng.
 Journal of Mathematical Biology;J. Math. Biol.
 Journal of Mathematical Chemistry;J. Math. Chem.
+Journal of Medical Hypotheses & Ideas;J. Med. Hypotheses Ideas;;
+Journal of Medical Imaging;J. Med. Imaging;;
 Journal of Medical Microbiology;J. Med. Microbiol.
+Journal of Medical Radiation Sciences;J. Med. Radiat. Sci.;;
 Journal of Medicinal Chemistry;J. Med. Chem.
 Journal of Membrane Biology;J. Membr. Biol.
 Journal of Membrane Science;J. Membr. Sci.
+Journal of Metallurgy and Materials Science;J. Metall. Mater. Sci.;;
 Journal of Micro/Nanolithography, Microfabrican, and Microsystems;J. Micro/Nanolithog. Microfab. Microsys.
 Journal of Microbiological Methods;J. Microbiol. Methods
 Journal of Microbiology and Biotechnology;J. Microbiol. Biotechnol.
 Journal of Microcolumn Separations;J. Microcolumn Sep.
 Journal of Microelectronic Systems;J. Microelectromech. Syst.
+Journal of Microelectronics and Electronic Packaging;J. Microelectron. Electron. Packag.;;
 Journal of Microencapsulation;J. Microencapsulation
 Journal of Microlithography, Microfabrication, and Microsystems;J. Microlith. Microfab. Microsys.
 Journal of Micromechanics and Microengineering;J. Micromech. Microeng.
 Journal of Microscopy;J. Microsc.
 Journal of Modern Optics;J. Mod. Opt.
-Journal of Molecular and Cellular Cardiology;J. Mol. Cell. Cardiol.
+Journal of Modern Power Systems and Clean Energy;J. Mod Power Syst. Clean Energy;;
 Journal of Molecular Biology;J. Mol. Biol.
 Journal of Molecular Catalysis;J. Mol. Catal.
 Journal of Molecular Catalysis A: Chemical;J. Mol. Catal. A: Chem.
@@ -2542,10 +3025,13 @@ Journal of Molecular Liquids;J. Mol. Liq.
 Journal of Molecular Microbiology and Biotechnology;J. Mol. Microbiol. Biotechnol.
 Journal of Molecular Modeling;J. Mol. Model.
 Journal of Molecular Neuroscience;J. Mol. Neurosci.
+Journal of Molecular Psychiatry;J. Mol. Psychiatry;;
 Journal of Molecular Recognition;J. Mol. Recognit.
 Journal of Molecular Spectroscopy;J. Mol. Spectrosc.
 Journal of Molecular Structure;J. Mol. Struct.
+Journal of Molecular and Cellular Cardiology;J. Mol. Cell. Cardiol.
 Journal of Morphology;J. Morphol.
+Journal of Nano Energy and Power Research;J. Nano Energy Power Res.;;
 Journal of Nanoparticle Research;J. Nanopart. Res.
 Journal of Nanoscience and Nanotechnology;J. Nanosci. Nanotechnol.
 Journal of Natural Gas Chemistry;J. Nat. Gas Chem.
@@ -2554,12 +3040,16 @@ Journal of Near Infrared Spectroscopy;J. Near Infrared Spectrosc.
 Journal of Nematology;J. Nematol.
 Journal of Neural Engineering;J. Neural Eng.
 Journal of Neural Transmission: General Section;J. Neural Transm.: Gen. Sect.
+Journal of NeuroEngineering and Rehabilitation;J. NeuroEng. Rehabil.;;
 Journal of Neurochemistry;J. Neurochem.
 Journal of Neuroendocrinology;J. Neuroendocrinol.
+Journal of Neuroimmune Pharmacology;J. Neuroimmune Pharmacol.;;
 Journal of Neuroimmunology;J. Neuroimmunol.
 Journal of Neurophysiology;J. Neurophysiol.
 Journal of Neuroscience;J. Neurosci.
 Journal of Neuroscience Research;J. Neurosci. Res.
+Journal of New England Water Environment Association;J. N. Engl. Water Environ. Assoc.;;
+Journal of New England Water Works Association;J. N. Engl. Water Works Assoc.;;
 Journal of New Materials for Electrochemical Systems;J. New Mater. Electrochem. Syst.
 Journal of Non-Crystalline Solids;J. Non-Cryst. Solids
 Journal of Non-Equilibrium Thermodynamics;J. Non-Equilib. Thermodyn.
@@ -2569,31 +3059,37 @@ Journal of Nuclear Energy, Part A: Reactor Science;J. Nuclear Eng. Part A:
 Journal of Nuclear Energy, Part B: Reactor Technology;J. Nuclear Eng. Part B:
 Journal of Nuclear Energy, Part C: Plasma Physics, Accelerators, Thermonuclear Research;J. Nuclear Eng. Part C:
 Journal of Nuclear Materials;J. Nucl. Mater.
-Journal of Nuclear Science and Technology (Tokyo, Japan);J. Nucl. Sci. Technol. (Tokyo, Jpn.)
 Journal of Nuclear Science and Technology;J. Nucl. Sci. Technol.
+Journal of Nuclear Science and Technology (Tokyo, Japan);J. Nucl. Sci. Technol. (Tokyo, Jpn.)
 Journal of Nutrition;J. Nutr.
 Journal of Nutritional Biochemistry;J. Nutr. Biochem.
 Journal of Nutritional Science and Vitaminology;J. Nutr. Sci. Vitaminol.
+Journal of Ocean Technology;J. Ocean Technol.;;
 Journal of Ocular Pharmacology and Therapeutics;J. Ocul. Pharmacol. Ther.
 Journal of Oleo Science;J. Oleo Sci.
+Journal of Operational Meteorology;J. Oper. Meteorol.;;
 Journal of Optical Communication;J. Opt. Commun.
 Journal of Optics;J. Opt.
 Journal of Optics A: Pure and Applied Optics;J. Opt. A: Pure Appl. Opt.
 Journal of Optics B: Quantum and Semiclassical Optics;J. Opt. B: Quantum Semiclassical Opt.
 Journal of Organic Chemistry;J. Org. Chem.
 Journal of Organometallic Chemistry;J. Organomet. Chem.
+Journal of Pain;J. Pain;;
 Journal of Peptide Research;J. Pept. Res.
 Journal of Peptide Science;J. Pept. Sci.
 Journal of Petroleum Science & Engineering;J. Pet. Sci. Eng.
 Journal of Petroleum Science and Technology;J. Pet. Sci. Technol.
 Journal of Petrology;J. Petrol.
-Journal of Pharmaceutical and Biomedical Analysis;J. Pharm. Biomed. Anal.
+Journal of Pharmaceutical Analysis;J. Pharm. Anal.;;
+Journal of Pharmaceutical Policy and Practice;J. Pharm. Policy Pract.;;
 Journal of Pharmaceutical Sciences;J. Pharm. Sci.
+Journal of Pharmaceutical and Biomedical Analysis;J. Pharm. Biomed. Anal.
 Journal of Pharmacobio-Dynamics;J. Pharmacobio-Dyn.
 Journal of Pharmacokinetics and Biopharmaceutics;J. Pharmacokinet. Biopharm.
-Journal of Pharmacological and Toxicological Methods;J. Pharmacol. Toxicol. Methods
 Journal of Pharmacological Sciences (Tokyo, Japan);J. Pharmacol. Sci. (Tokyo, Jpn.)
+Journal of Pharmacological and Toxicological Methods;J. Pharmacol. Toxicol. Methods
 Journal of Pharmacology and Experimental Therapeutics;J. Pharmacol. Exp. Ther.
+Journal of Pharmacy Research;J. Pharm. Res.;;
 Journal of Pharmacy and Pharmacology;J. Pharm. Pharmacol.
 Journal of Phase Equilibria;J. Phase Equilib.
 Journal of Phase Equilibria and Diffusion;J. Phase Equilib. Diffus.
@@ -2601,36 +3097,41 @@ Journal of Photochemistry and Photobiology, A: Chemistry;J. Photochem. Photobiol
 Journal of Photochemistry and Photobiology, B: Biology;J. Photochem. Photobiol., B
 Journal of Photochemistry and Photobiology, C: Photochemistry Reviews;J. Photochem. Photobiol., C
 Journal of Photogrammetry and Remote Sensing;J. Photogramm. Remote Sens.
+Journal of Photonics for Energy;J. Photonics Energy;;
 Journal of Photopolymer Science and Technology;J. Photopolym. Sci. Technol.
-Journal of Physical and Chemical Reference Data;J. Phys. Chem. Ref. Data
+Journal of Phycology;J. Phycol.;;
 Journal of Physical Chemistry;J. Phys. Chem.
 Journal of Physical Chemistry A;J. Phys. Chem. A
 Journal of Physical Chemistry B;J. Phys. Chem. B
 Journal of Physical Chemistry C;J. Phys. Chem. C
 Journal of Physical Organic Chemistry;J. Phys. Org. Chem.
+Journal of Physical and Chemical Reference Data;J. Phys. Chem. Ref. Data
 Journal of Physics;J. Phys.
 Journal of Physics A: General Physics;J. Phys. A: Gen. Phys.
 Journal of Physics A: Mathematical and General;J. Phys. A: Math. Gen.
 Journal of Physics A: Mathematical and Theoretical;J. Phys. A: Math. Theor.
 Journal of Physics A: Mathematical, Nuclear and General;J. Phys. A: Math. Nucl. Gen.
-Journal of Physics and Chemistry of Solids;J. Phys. Chem. Solids
 Journal of Physics B: Atomic, Molecular and Optical Physics;J. Phys. B: At., Mol. Opt. Phys.
 Journal of Physics C: Solid State Physics;J. Phys. C: Solid State Phys.
 Journal of Physics D: Applied Physics;J. Phys. D: Appl. Phys.
 Journal of Physics E: Scientific Instruments;J. Phys. E: Sci. Instrum.
 Journal of Physics F: Metal Physics;J. Phys, F: Met. Phys.
 Journal of Physics G: Nuclear and Particle Physics;J. Phys. G: Nucl. Part. Phys.
+Journal of Physics and Chemistry of Solids;J. Phys. Chem. Solids
 Journal of Physics: Condensed Matter;J. Phys.: Condens. Matter
 Journal of Physics: Conference Series;J. Phys: Conf. Ser.
 Journal of Physiology (Oxford, United Kingdom);J. Physiol. (Oxford, U. K.)
+Journal of Phytopathology;J. Phytopathol.;;
 Journal of Pineal Research;J. Pineal Res.
 Journal of Planar Chromatography--Modern TLC;J. Planar Chromatogr.--Mod. TLC
 Journal of Plankton Research;J. Plankton Res.
 Journal of Plant Biochemistry and Biotechnology;J. Plant Biochem. Biotechnol.
+Journal of Plant Diseases and Protection;J. Plant Dis. Prot.;;
 Journal of Plant Growth Regulation;J. Plant Growth Regul.
 Journal of Plant Nutrition;J. Plant Nutr.
 Journal of Plant Nutrition and Soil Science;J. Plant Nutr. Soil Sci.
 Journal of Plant Physiology;J. Plant Physiol.
+Journal of Plant Protection Research;J. Plant Prot. Res.;;
 Journal of Polymer Engineering;J. Polym. Eng.
 Journal of Polymer Materials;J. Polym. Mater.
 Journal of Polymer Research;J. Polym. Res.
@@ -2639,6 +3140,7 @@ Journal of Polymer Science, Part B: Polymer Physics;J. Polym. Sci., Part B: Poly
 Journal of Polymers and the Environment;J. Polym. Environ.
 Journal of Porous Materials;J. Porous Mater.
 Journal of Porphyrins and Phthalocyanines;J. Porphyrins Phthalocyanines
+Journal of Power Electronics;J. Power Electron.;;
 Journal of Power Sources;J. Power Sources
 Journal of Process Control;J. Process Control
 Journal of Propulsion and Power;J. Propul. Power
@@ -2647,35 +3149,45 @@ Journal of Proteome Research;J. Proteome Res.
 Journal of Pulp and Paper Science;J. Pulp Pap. Sci.
 Journal of Quantitative Spectroscopy & Radiative Transfer;J. Quant. Spectrosc. Radiat. Transfer
 Journal of Quaternary Science;J. Quat. Sci.
+Journal of Radiation Research and Applied Sciences;J. Radiat. Res. Appl. Sci.;;
 Journal of Radioanalytical and Nuclear Chemistry;J. Radioanal. Nucl. Chem.
 Journal of Radioanalytical and Nuclear Chemistry Articles;J. Radioanal. Nucl. Chem. Art.
 Journal of Radioanalytical and Nuclear Chemistry Letters;J. Radioanal. Nucl. Chem. Lett.
 Journal of Radiological Protection;J. Radiol. Prot.
+Journal of Rail Transport Planning and Management;J. Rail Transp. Plann. Manage.;;
 Journal of Raman Spectroscopy;J. Raman Spectrosc.
 Journal of Range Management;J. Range Manage.
 Journal of Rapid Methods and Automation in Microbiology;J. Rapid Methods Autom. Microbiol.
 Journal of Receptors and Signal Transduction;J. Recept. Signal Transduction
 Journal of Reinforced Plastics and Composites;J. Reinf. Plast. Compos.
+Journal of Remanufacturing;J. Remanuf.;;
 Journal of Reproduction and Fertility;J. Reprod. Fertil.
+Journal of Residuals Science and Technology;J. Residuals Sci. Technol.;;
 Journal of Rheology (Melville, NY, United States);J. Rheol. (Melville, NY, U. S.)
 Journal of Rheology (New York, NY, United States);J. Rheol. (N. Y., NY, U. S.)
+Journal of Rock Mechanics and Geotechnical Engineering;J. Rock Mech. Geotech. Eng.;;
 Journal of Rural Studies;J. Rural Stud.
-Journal of Scientific and Industrial Research;J. Sci. Ind. Res.
+Journal of Scientific Conference Proceedings;J. Sci. Conf. Proc.;;
 Journal of Scientific Instruments;J. Sci. Instrum.
+Journal of Scientific and Industrial Research;J. Sci. Ind. Res.
+Journal of Seismic Exploration;J. Seismic Explor.;;
+Journal of Sensors and Sensor Systems;J. Sens. Sens. Syst.;;
 Journal of Separation Science;J. Sep. Sci.
-Journal of Soil and Water Conservation;J. Soil Water Conserv.
 Journal of Soil Science, The;J. Soil Sci.
+Journal of Soil and Water Conservation;J. Soil Water Conserv.
 Journal of Sol-Gel Science and Technology;J. Sol-Gel Sci. Technol.
 Journal of Solid State Chemistry;J. Solid State Chem.
 Journal of Solid State Electrochemistry;J. Solid State Electrochem.
 Journal of Solution Chemistry;J. Solution Chem.
+Journal of Space Weather and Space Climate;J. Space Weather Space Clim.;;
 Journal of Statistical Computation and Simulation;J. Stat. Comput. Simul.
 Journal of Statistical Mechanics: Theory and Experiment;J. Stat. Mech: Theory Exp.
 Journal of Statistical Planning and Inference;J. Stat. Plan. Inference
 Journal of Steroid Biochemistry and Molecular Biology;J. Steroid Biochem. Mol. Biol.
 Journal of Strain Analysis for Engineering Design;J. Strain Anal. Eng. Des.
-Journal of Structural and Functional Genomics;J. Struct. Funct. Genomics
 Journal of Structural Chemistry;J. Struct. Chem.
+Journal of Structural and Functional Genomics;J. Struct. Funct. Genomics
+Journal of Studies on Alcohol and Drugs;J. Stud. Alcohol Drugs;;
 Journal of Sulfur Chemistry;J. Sulfur Chem.
 Journal of Superconductivity;J. Supercond.
 Journal of Superconductivity and Novel Magnetism;J. Supercond. Novel Magn.
@@ -2684,13 +3196,58 @@ Journal of Supramolecular Chemistry;J. Supramol. Chem.
 Journal of Surfactants and Detergents;J. Surfactants Deterg.
 Journal of Surgical Research;J. Surg. Res.
 Journal of Sustainable Forestry;J. Sustainable For.
+Journal of Symplectic Geometry;J. Symplectic Geom.;;
 Journal of Synthetic Lubrication;J. Synth. Lubr.
 Journal of Synthetic Organic Chemistry, Japan;J. Synth. Org. Chem Jpn.
+Journal of Systems Chemistry;J. Syst. Chem.;;
+Journal of Systems Engineering and Electronics;J. Syst. Eng. Electron.;;
 Journal of Terramechanics;J. Terramech.
 Journal of Testing and Evaluation;J. Test. Eval.
-Journal of the Air and Waste Management Association;J. Air Waste Manage. Assoc.
-Journal of the Air and Waste Management Association;J. Air Waste Manage. Assoc.
+Journal of Theoretical & Computational Chemistry;J. Theor. Comput. Chem.
+Journal of Theoretical Biology;J. Theor. Biol.
+Journal of Therapeutic Ultrasound;J. Ther. Ultrasound;;
+Journal of Thermal Analysis;J. Therm. Anal.
+Journal of Thermal Analysis and Calorimetry;J. Therm. Anal. Calorim.
+Journal of Thermal Science and Technology;J. Them. Sci. Technol.
+Journal of Thermal Spray Technology;J. Therm. Spray Technol.
+Journal of Thermophysics and Heat Transfer;J. Thermophys. Heat Transfer
+Journal of Thermoplastic Composite Materials;J. Thermoplast. Compos. Mater.
+Journal of Time Series Analysis;J. Time Ser. Anal.
+Journal of Tissue Engineering and Regenerative Medicine;J. Tissue Eng. Regener. Med.;;
+Journal of Toxicology - Clinical Toxicology;J. Toxicol., Clin. Toxicol.
+Journal of Toxicology - Cutaneous and Ocular Toxicology;J. Toxicol., Cutaneous Ocul. Toxicol.
+Journal of Toxicology - Toxin Reviews;J. Toxicol., Toxin Rev.
+Journal of Toxicology and Environmental Health;J. Toxicol. Environ. Health
+Journal of Toxicology and Environmental Health, Part A;J. Toxicol. Environ. Health, Part A
+Journal of Toxicology and Environmental Health, Part B: Critical Reviews;J. Toxicol. Environ. Health, Part B
+Journal of Trace Elements in Experimental Medicine;J. Trace Elem. Exp. Med.
+Journal of Trace Elements in Medicine and Biology;J. Trace Elem. Med Biol.
+Journal of Trace and Microprobe Techniques;J. Trace Microprobe Tech.
+Journal of Tropical Ecology;J. Trop. Ecol.
+Journal of Tropical Forest Science;J. Trop. For. Sci.;;
+Journal of Tropical Geography;J. Trop. Geogr.
+Journal of Uncertainty Analysis and Applications;J. Uncertainty Anal. Appl.;;
+Journal of Urban Ecology;J. Urban Ecol.;;
+Journal of Vacuum Science & Technology, A: Vacuum, Surfaces, and Films;J. Vac. Sci. Technol., A
+Journal of Vacuum Science & Technology, B: Microelectronics Processing and Phenomena;J. Vac. Sci. Technol., B
+Journal of Vacuum Science & Technology, B: Microelectronics and Nanometer Structures--Processing, Measurement, and Phenomena;J. Vac. Sci. Technol., B: Microelectron. Nanometer Struct.--Process., Meas., Phenom.
+Journal of Vegetation Science;J. Veg. Sci.
+Journal of Venomous Animals and Toxins Including Tropical Diseases;J. Venomous Anim. Toxins Incl. Trop. Dis.;;
+Journal of Vinyl & Additive Technology;J. Vinyl Addit. Technol.
+Journal of Virological Methods;J. Virol. Methods
+Journal of Virology;J. Virol.
+Journal of Volcanology and Geothermal Research;J. Volcanol. Geotherm. Res.
+Journal of Water Process Engineering;J. Water Process Eng.;;
+Journal of Water and Climate Change;J. Water Clim. Change;;
+Journal of Wetlands Ecology;J. Wetlands Ecol.;;
+Journal of Wide Bandgap Materials;J. Wide Bandgap Mater.
+Journal of Wildlife Management;J. Wildl. Manage.
+Journal of Women and Minorities in Science and Engineering;J. Women Minorities Sci. Eng.;;
+Journal of Wood Chemistry and Technology;J. Wood Chem. Technol.
+Journal of Zoological Systematics and Evolutionary Research;J. Zool. Syst. Evol. Res.;;
+Journal of Zoology (London);J. Zool. (London)
 Journal of the Air Pollution Control Association;J. Air Pollut. Control Assoc.
+Journal of the Air and Waste Management Association;J. Air Waste Manage. Assoc.
 Journal of the American Association for Laboratory Animal Science;J. Am. Assoc. Lab. Anim. Sci.
 Journal of the American Ceramic Society;J. Am. Ceram. Soc.
 Journal of the American Chemical Society;J. Am. Chem. Soc.
@@ -2700,11 +3257,14 @@ Journal of the American Society for Horticultural Science;J. Am. Soc. Hortic. Sc
 Journal of the American Society for Mass Spectrometry;J. Am. Soc. Mass Spectrom.
 Journal of the American Society of Brewing Chemists;J. Am. Soc. Brew. Chem.
 Journal of the American Statistical Association;J. Am. Stat. Assoc.
-Journal of the American Statistical Association;J. Am. Stat. Assoc.
 Journal of the Argentine Chemical Society;J. Argent. Chem. Soc.
+Journal of the Association for Crime Scene Reconstruction;J. Assoc. Crime Scene Reconstr.;;
 Journal of the Association of Public Analysts;J. Assoc. Public Anal.
 Journal of the Brazilian Chemical Society;J. Braz. Chem. Soc.
+Journal of the Brazilian Computer Society;J. Braz. Comput. Soc.;;
 Journal of the British Grassland Society;J. Br. Grassl. Soc.
+Journal of the British Institution of Radio Engineers;J. Br. Inst. Radio Eng.;;
+Journal of the British Interplanetary Society;J. Br. Interplanet. Soc.;;
 Journal of the British Waterworks Association;J. Br. Waterworks Assoc.
 Journal of the Ceramic Society of Japan;J. Ceram. Soc. Jpn.
 Journal of the Chemical Society;J. Chem. Soc.
@@ -2717,6 +3277,7 @@ Journal of the Chemical Society, Perkin Transactions 2;J. Chem. Soc., Perkin Tra
 Journal of the Chilean Chemical Society;J. Chil. Chem. Soc.
 Journal of the Chinese Chemical Society (Taipei, Taiwan);J. Chin. Chem. Soc. (Taipei, Taiwan)
 Journal of the Chinese Institute of Chemical Engineers;J. Chin. Inst. Chem. Eng.
+Journal of the Earth and Space Physics;J. Earth Space Phys.;;
 Journal of the Electrochemical Society;J. Electrochem. Soc.
 Journal of the Electrochemical Society of India;J. Electrochem. Soc. India
 Journal of the Energy Institute;J. Energy Inst.
@@ -2728,6 +3289,7 @@ Journal of the Forensic Science Society;J. Forensic Sci. Soc.
 Journal of the Franklin Institute;J. Franklin Inst.
 Journal of the Geological Society (London, United Kingdom);J. Geol. Soc. (London, U.K.)
 Journal of the Geological Society of Australia;J. Geol. Soc. Aust.
+Journal of the Geological Society of China;J. Geol. Soc. China;;
 Journal of the Hattori Botanical Laboratory;J. Hattori Bot. Lab.
 Journal of the Indian Academy of Forensic Sciences;J. Indian Acad. Forensic Sci.
 Journal of the Indian Chemical Society;J. Indian Chem. Soc.
@@ -2737,9 +3299,14 @@ Journal of the Institute of Brewing;J. Inst. Brew.
 Journal of the Institute of Energy;J. Inst. Energy
 Journal of the Institute of Environment Sciences;J. Inst. Environ. Sci.
 Journal of the Institution of Chemists (India);J. Inst. Chem. (India)
+Journal of the Institution of Electrical Engineers;J. Inst. Electr. Eng.;;
+Journal of the Institution of Electronic and Radio Engineers;J. Inst. Electron. Radio Eng.;;
+Journal of the Institution of Production Engineers;J. Inst. Prod. Eng.;;
 Journal of the Institution of Water and Environment Management;J. Inst. Water Environ. Manage.
+Journal of the International Society of Sports Nutrition;J. Int. Soc. Sports Nutr.;;
 Journal of the Japan Institute of Metals;J. Jpn. Inst. Met.
 Journal of the Japan Petroleum Institute;J. Jpn. Pet. Inst.
+Journal of the Korea Institute of Applied Superconductivity and Cryogenics;J. Korea Inst. Appl. Supercond. Cryog. Inst.;;
 Journal of the Korean Ceramic Society;J. Korean Ceram. Soc.
 Journal of the Korean Chemical Society;J. Korean Chem. Soc.
 Journal of the Marine Biology Association of the United Kingdom;J. mar. biol. Ass. U.K.
@@ -2748,6 +3315,7 @@ Journal of the National Cancer Institute (1988);J. Natl. Cancer Inst.
 Journal of the Optical Society of America;J. Opt. Soc. Am.
 Journal of the Optical Society of America A: Optics, Image Science, and Vision;J. Opt. Soc. Am. A
 Journal of the Optical Society of America B: Optical Physics;J. Opt. Soc. Am. B
+Journal of the Optical Society of Korea;J. Opt. Soc. Korea;;
 Journal of the Physical Society of Japan;J. Phys. Soc. Jpn.
 Journal of the Royal Statistical Society;J. R. Stat. Soc.
 Journal of the Royal Statistical Society: Series B (Statistical Methodology);J. R. Stat. Soc. B
@@ -2758,54 +3326,24 @@ Journal of the Society for Radiological Protection;J. Soc. Radiol. Prot.
 Journal of the Society of Dyers and Colourists;J. Soc. Dyers Colour.
 Journal of the Society of Inorganic Materials, Japan;J. Soc. Inorg. Mater., Jpn.
 Journal of the Society of Leather Technologists and Chemists;J. Soc. Leather Technol. Chem.
+Journal of the South African Institute of Civil Engineering;J. South Afr. Inst. Civil Eng.;;
 Journal of the South African Institute of Mining and Metallurgy;J. S. Afr. Inst. Min. Metall.
+Journal of the Torrey Botanical Society;J. Torrey Bot. Soc.;;
 Journal of the World Aquaculture Society;J. World Aquacult. Soc.
-Journal of Theoretical & Computational Chemistry;J. Theor. Comput. Chem.
-Journal of Theoretical Biology;J. Theor. Biol.
-Journal of Thermal Analysis;J. Therm. Anal.
-Journal of Thermal Analysis and Calorimetry;J. Therm. Anal. Calorim.
-Journal of Thermal Science and Technology;J. Them. Sci. Technol.
-Journal of Thermal Spray Technology;J. Therm. Spray Technol.
-Journal of Thermophysics and Heat Transfer;J. Thermophys. Heat Transfer
-Journal of Thermoplastic Composite Materials;J. Thermoplast. Compos. Mater.
-Journal of Time Series Analysis;J. Time Ser. Anal.
-Journal of Toxicology - Clinical Toxicology;J. Toxicol., Clin. Toxicol.
-Journal of Toxicology - Cutaneous and Ocular Toxicology;J. Toxicol., Cutaneous Ocul. Toxicol.
-Journal of Toxicology - Toxin Reviews;J. Toxicol., Toxin Rev.
-Journal of Toxicology and Environmental Health;J. Toxicol. Environ. Health
-Journal of Toxicology and Environmental Health, Part A;J. Toxicol. Environ. Health, Part A
-Journal of Toxicology and Environmental Health, Part B: Critical Reviews;J. Toxicol. Environ. Health, Part B
-Journal of Trace and Microprobe Techniques;J. Trace Microprobe Tech.
-Journal of Trace Elements in Experimental Medicine;J. Trace Elem. Exp. Med.
-Journal of Trace Elements in Medicine and Biology;J. Trace Elem. Med Biol.
-Journal of Tropical Ecology;J. Trop. Ecol.
-Journal of Tropical Geography;J. Trop. Geogr.
-Journal of Vacuum Science & Technology, A: Vacuum, Surfaces, and Films;J. Vac. Sci. Technol., A
-Journal of Vacuum Science & Technology, B: Microelectronics and Nanometer Structures--Processing, Measurement, and Phenomena;J. Vac. Sci. Technol., B: Microelectron. Nanometer Struct.--Process., Meas., Phenom.
-Journal of Vacuum Science & Technology, B: Microelectronics Processing and Phenomena;J. Vac. Sci. Technol., B
-Journal of Vegetation Science;J. Veg. Sci.
-Journal of Vinyl & Additive Technology;J. Vinyl Addit. Technol.
-Journal of Virological Methods;J. Virol. Methods
-Journal of Virology;J. Virol.
-Journal of Volcanology and Geothermal Research;J. Volcanol. Geotherm. Res.
-Journal of Wide Bandgap Materials;J. Wide Bandgap Mater.
-Journal of Wildlife Management;J. Wildl. Manage.
-Journal of Wood Chemistry and Technology;J. Wood Chem. Technol.
-Journal of Zoology (London);J. Zool. (London)
-JPC Journal of Planar Chromatography Modern TLC;JPC J. Planar Chromatogr. - Mod. TLC
-JSME International Journal Series A: Mechanics and Material Engineering;JSME Int J., Ser. A
-JSME International Journal Series B: Fluids and Thermal Engineering;JSME Int J., Ser. B
-JSME International Journal Series C: Mechanical Systems Machine Elements and Manufacturing;JSME Int J., Ser. C
+KEK Proceedings;KEK Proc.
+KGK, Kautschuk Gummi Kunststoffe;KGK, Kautsch. Gummi Kunstst.
+KORA Bericht;KORA Ber.
+KSII Transactions on Internet and Information Systems;KSII Trans. Internet Inf. Syst.;;
 Kagaku (Kyoto);Kagaku (Kyoto)
 Kagaku Kogaku;Kagaku Kogaku
 Kagaku Kogaku Ronbunshu;Kagaku Kogaku Ronbunshu
 Kagaku to Seibutsu;Kagaku to Seibutsu
 Kako Gijutsu (Osaka);Kako Gijutsu (Osaka)
 Kan, Tan, Sui;Kan, Tan, Sui
+Karbala International Journal of Modern Science;Karbala Int. J. Mod. Sci.;;
 Karstenia;Karstenia
 Kauchuk i Rezina;Kauch. Rezina
 Kautschuk Gummi Kunststoffe;Kautsch. Gummi Kunstst.
-KEK Proceedings;KEK Proc.
 Kemia - Kemi;Kem.-Kemi
 Kemija u Industriji;Kem. Ind.
 Kemikaru Enjiniyaringu;Kemikaru Enjiniyaringu
@@ -2813,7 +3351,6 @@ Kemisk Tidskrift;Kem. Tidskr.
 Keramische Zeitschrift;Keram. Z.
 Kew Bulletin;Kew Bull.
 Key Engineering Materials;Key Eng. Mater.
-KGK, Kautschuk Gummi Kunststoffe;KGK, Kautsch. Gummi Kunstst.
 Khimicheskaya Fizika;Khim. Fiz.
 Khimicheskaya Promyshlennost (St. Petersburg, Russian Federation);Khim. Prom-st. (St. Petersburg, Russ. Fed.)
 Khimicheskaya Promyshlennost Segodnya;Khim. Prom-st. Segodnya
@@ -2822,12 +3359,12 @@ Khimicheskoe i Neftyanoe Mashinostroenie;Khim. Neft. Mashinostr.
 Khimiko-Farmatsevticheskii Zhurnal;Khim.-Farm. Zh.
 Khimiya Drevesiny;Khim. Drev.
 Khimiya Geterotsiklicheskikh Soedinenii;Khim. Geterotsikl. Soedin.
-Khimiya i Tekhnologiya Topliv i Masel;Khim. Tekhnol. Topl. Masel
-Khimiya i Tekhnologiya Vody;Khim. Tekhnol. Vody
 Khimiya Prirodnykh Soedinenii;Khim. Prir. Soedin.
 Khimiya Tverdogo Topliva (Moscow, Russian Federation);Khim. Tverd. Topl. (Moscow, Russ. Fed.)
-Khimiya v Interesakh Ustoichivogo Razvitiya;Khim. Interesakh Ustoich. Razvit.
 Khimiya Vysokikh Energii;Khim. Vys. Energ.
+Khimiya i Tekhnologiya Topliv i Masel;Khim. Tekhnol. Topl. Masel
+Khimiya i Tekhnologiya Vody;Khim. Tekhnol. Vody
+Khimiya v Interesakh Ustoichivogo Razvitiya;Khim. Interesakh Ustoich. Razvit.
 Khimizatsiya Sel'skogo Khozyaistva;Khim. Sel'sk. Khoz.
 Kidney International;Kidney Int.
 Kinetics and Catalysis;Kinet. Catal.
@@ -2843,15 +3380,21 @@ Kolloidn Zhurnal;Kolloidn Zh.
 Kolloidnyi Zhurnal;Kolloidn. Zh.
 Kompetenz-Zentrum Holz;Kompet.-Zent. Holz
 Kompleksnoe Ispol'zovanie Mineral'nogo Syr'ya;Kompleksn. Ispol'z. Miner. Syr'ya
+Kona Powder and Particle Journal;Kona Powder Part. J.;;
 Koordinatsionnaya Khimiya (Russian Journal of Coordination Chemistry);Koord. Khim.
-KORA Bericht;KORA Ber.
 Korean Journal of Chemical Engineering;Korean J. Chem. Eng.
+Korean Journal of Materials Research;Korean J. Mater. Res.;;
+Korean Journal of Physiology & Pharmacology;Korean J. Physiol. Pharmacol.;;
 Kovove Materialy Metallic Materials;Kovove Mater.
 Kozhevenno-Obuvnaya Promyshlennost;Kozh.-Obuvn. Prom-st.
 Kratkie Soobshcheniya po Fizike;Kratk. Soobshch. Fiz.
 Kristallografiya;Kristallografiya
 Kunststoffe;Kunststoffe
 Kvantovaya Elektronika (Moscow);Kvantovaya Elektron. (Moscow)
+LC-GC;LC-GC
+LC-GC The Magazine of Separation Science;LC-GC
+LCGC North America;LCGC North Am.
+LWT--Food Science and Technology;LWT--Food Sci. Technol.
 Lab on a Chip;Lab Chip
 Laboratory Animals;Lab. Anim.
 Laboratory Automation and Information Management;Lab. Autom. Inf. Manage.
@@ -2859,11 +3402,13 @@ Laboratory Investigation;Lab. Invest.
 Laboratory Practice;Lab. Pract.
 Laboratory Robotics and Automation;Lab. Rob. Autom.
 Lakokrasochnye Materialy i Ikh Primenenie;Lakokras. Mater. Ikh Primen.
+Lancet Diabetes and Endocrinology;Lancet Diabetes Endocrinol.;;
 Land Use Policy;Land Use Policy
 Landeshydrologie und -geologie, Mitteilung;Landeshydrol. -geol., Mitt.
-Landscape and Urban Planning;Landsc. Urban Plan.
 Landscape Ecology;Landsc. Ecol.
 Landscape Journal;Landsc. J.
+Landscape Research;Landscape Res.;;
+Landscape and Urban Planning;Landsc. Urban Plan.
 Landschaft Aargau;Landsch. Aargau
 Landschaftsentwicklung und Umweltforschung;Landsch.entwickl. Umweltforsch.
 Landschaftsgenese und Landschaftsökologie;Landsch.genes. Landsch.ökol.
@@ -2872,16 +3417,14 @@ Landschaftsökologie und Umweltforschung;Landsch.ökol. Umweltforsch.
 Landwirtschaftliche Forschung;Landwirtsch. Forsch.
 Landwirtschaftliches Jahrbuch der Schweiz;Landwirtsch. Jahrb. Schweiz
 Langmuir;Langmuir
-Laser and Particle Beams;Laser Part. Beams
-Laser and Photonics Reviews;Laser Photonic Rev.
 Laser Chemistry;Laser Chem.
 Laser Physics Letters;Laser Phys. Lett.
+Laser and Particle Beams;Laser Part. Beams
+Laser and Photonics Reviews;Laser Photonic Rev.
+Lasers in Medical Science;Lasers Med. Sci.;;
 Latin American Journal of Pharmacy;Lat. Am. J. Pharm.
 Latvijas Kimijas Zurnals;Latv. Kim. Z.
 Laufener Seminarbeiträge;Laufener Semin.beitr.
-LC-GC;LC-GC
-LC-GC The Magazine of Separation Science;LC-GC
-LCGC North America;LCGC North Am.
 Leaflet Agricultural Research Organization, Division of Forestry;Leafl. Agric. Res. Organ., Div. For.
 Lebensmittel-Wissenschaft und -Technologie;Lebensm.-Wiss. Technol.
 Lecture Notes in Earth Sciences;Lect. Notes Earth Sci.
@@ -2896,14 +3439,20 @@ Liebigs Annalen - Recueil;Liebigs Ann. Recl.
 Liebigs Annalen der Chemie;Liebigs Ann. Chem.
 Lietuvos Fizikos Rinkinys;Liet. Fiz. Rinkinys
 Life Sciences;Life Sci.
+Life Sciences in Space Research;Life Sci. Space Res.;;
 Light Metals (Warrendale, Pennsylvania);Light Met. (Warrendale, Pa.)
 Lihua Jianyan, Huaxue Fence;Lihua Jianyan, Huaxue Fence
 Limnologica;Limnologica
 Limnology and Oceanography;Limnol. Oceanogr.
+Limnology and Oceanography Bulletin;Limnol. Oceanogr. Bull.;;
+Limnology and Oceanography: Fluids and Environments;Limnol. Oceanogr. Fluids Environ.;;
+Limnology and Oceanography: Methods;Limnol. Oceanogr. Methods;;
 Limosa;Limosa
 Linchan Huaxue Yu Gongye;Linchan Huaxue Yu Gongye
 Lindbergia;Lindbergia
 Linea Ecologica;Linea Ecol.
+Linear Algebra and Its Applications;Linear Algebra Appl.;;
+Linguistic Inquiry;Ling. Inq.;;
 Linzer biologische Beiträge;Linz. biol. Beitr.
 Lipids;Lipids
 Liquid Crystals;Liq. Cryst.
@@ -2914,10 +3463,11 @@ Local land and soil news;Local land soil news
 Lubrication Engineering;Lubr. Eng.
 Lubrication Science;Lubr. Sci.
 Lundqua Report;Lundqua Rep.
-LWT--Food Science and Technology;LWT--Food Sci. Technol.
 LÖBF-Mitteilungen, Landesanstalt für Ökologie, Bodenordnung und Forsten / Landesamt für Agrarordnung, Nordrhein-Westfalen;LÖBF-Mitt., Landesanst. Ökol. Bodenordn. Forsten, Landesamt Agrarordn. Nordrh.-Westfal.
 LÖBF-Schriftenreihe, Landesanstalt für Ökologie, Bodenordnung und Forsten, Nordrhein-Westfalen;LÖBF-Schr.reihe, Landesanst. Ökol. Bodenordn. Forsten Nordrh.-Westfal.
 LÖLF-Mitteilungen, Landesanstalt für Ökologie, Landschaftsentwicklung und Forstplanung, Nordrhein-Westfalen;LÖLF-Mitt., Landesanst. Ökol. Landsch.entwickl.  Forstplan., Nordrh.-Westfal.
+MRS Bulletin;MRS Bull.
+MRS Internet Journal of Nitride Semiconductor Research;MRS Internet J. Nitride Semicond. Res.
 Macedonian Journal of Chemistry and Chemical Engineering;Maced. J. Chem. Chem. Eng.
 Macromolecular Bioscience;Macromol. Biosci.
 Macromolecular Chemistry and Physics;Macromol. Chem. Phys.
@@ -2927,12 +3477,12 @@ Macromolecular Reaction Engineering;Macromol. React. Eng.
 Macromolecular Research;Macromol. Res.
 Macromolecular Symposia;Macromol. Symp.
 Macromolecular Theory and Simulations;Macromol. Theory Simul.
-Macromolecules (Washington, DC, United States);Macromolecules (Washington, DC, U. S.)
 Macromolecules;Macromolecules
+Macromolecules (Washington, DC, United States);Macromolecules (Washington, DC, U. S.)
 Maejo International Journal of Science and Technology;Maejo Int. J. Sci. Technol.
 Magnesium Research;Magnesium Res.
-Magnetic Resonance in Chemistry;Magn. Reson. Chem.
 Magnetic Resonance Materials in Physics, Biology and Medicine;Magn. Reson. Mater. Phys., Biol. Med.
+Magnetic Resonance in Chemistry;Magn. Reson. Chem.
 Magyar Kemiai Folyoirat;Magy. Kem. Foly.
 Magyar Kemiai Folyoirat, Kemiai Kozlemenyek;Magy. Kem. Foly., Kem. Kozl.
 Magyar Kemikusok Lapja;Magy. Kem. Lapja
@@ -2948,24 +3498,28 @@ Malaysian Forester, The;Malays. For.
 Mammal Review;Mamm. Rev.
 Mammalia;Mammalia
 Mammalian Biology;Mamm. Biol.
+Mammalian Biology - Zeitschrift fur Saugetierkunde;Mamm. Biol. Z. Saugetierkd.;;
+Management Science;Manage. Sci.;;
 Mansoura Journal of Chemistry;Mansoura J. Chem.
 Manufacturing Chemist;Manuf. Chem.
 Manufacturing Engineering and Materials Processing;Manuf. Eng. Mater. Process.
+Manufacturing Review;Manuf. Rev.;;
 Maple Technical Newsletter, The;Maple Tech. Newsl.
 Marine & Freshwater Research;Mar. Freshwater Res.
 Marine Biology;Mar. Biol.
 Marine Biotechnology;Mar. Biotechnol.
 Marine Chemistry;Mar. Chem.
+Marine Drugs;Mar. Drugs;;
 Marine Ecology Progress Series;Mar. Ecol. Prog. Ser.
 Marine Environmental Research;Mar. Environ. Res.
+Marine Fisheries Review;Mar. Fish. Rev.;;
+Marine Geodesy;Mar. Geod.;;
+Marine Geophysical Research;Mar. Geophys. Res.;;
+Marine Mammal Science;Mar. Mammal Sci.;;
 Marine Pollution Bulletin;Mar. Pollut. Bull.
+Marine Resource Economics;Mar. Resour. Econ.;;
+Marine and Freshwater Behaviour and Physiology;Mar. Freshwater Behav. Physiol.;;
 Mass Spectrometry Reviews;Mass Spectrom. Rev.
-Materials and Corrosion;Mater. Corros.
-Materials and Design;Mater. Des.
-Materials and Manufacturing Processes;Mater. Manuf. Processes
-Materials and Organisms;Mater. Org.
-Materials and Structures;Mater. Struct.
-Materials at High Temperatures;Mater. High Temp.
 Materials Characterization;Mater. Charact.
 Materials Chemistry and Physics;Mater. Chem. Phys.
 Materials Engineering (Modena, Italy);Mater. Eng. (Modena, Italy)
@@ -2977,23 +3531,34 @@ Materials Research Bulletin;Mater. Res. Bull.
 Materials Research Innovations;Mater. Res. Innovations
 Materials Research Society Symposia Proceedings;Mater. Res. Soc. Symp. Proc.
 Materials Research Society Symposium Proceedings;Mater. Res. Soc. Symp. Proc.
+Materials Science;Mater. Sci.
 Materials Science & Engineering, A: Structural Materials: Properties, Microstructure and Processing;Mater. Sci. Eng., A
 Materials Science & Engineering, B: Solid-State Materials for Advanced Technology;Mater. Sci. Eng., B
 Materials Science & Engineering, C: Biomimetic and Supramolecular Systems;Mater. Sci. Eng., C
 Materials Science & Engineering, R: Reports;Mater. Sci. Eng., R
-Materials Science;Mater. Sci.
-Materials Science and Technology;Mater. Sci. Technol.
 Materials Science Forum;Mater. Sci. Forum
-Materials Science in Semiconductor Processing;Mater. Sci. Semicond. Process.
 Materials Science Monographs;Mater. Sci. Monogr.
 Materials Science Research International;Mater. Sci. Res. Int.
+Materials Science and Technology;Mater. Sci. Technol.
+Materials Science in Semiconductor Processing;Mater. Sci. Semicond. Process.
 Materials Technology;Mater. Technol.
 Materials Today;Mater. Today
+Materials Today Communications;Mater. Today Commun.;;
+Materials Today: Proceedings;Mater. Today:. Proc.;;
 Materials Transactions;Mater. Trans.
 Materials Transactions, JIM;Mater. Trans., JIM
+Materials and Corrosion;Mater. Corros.
+Materials and Design;Mater. Des.
+Materials and Manufacturing Processes;Mater. Manuf. Processes
+Materials and Organisms;Mater. Org.
+Materials and Structures;Mater. Struct.
+Materials at High Temperatures;Mater. High Temp.
+Materials for Renewable and Sustainable Energy;Mater. Renewable Sustainable Energy;;
 Materialwissenschaft und Werkstofftechnik;Materialwiss. Werkstofftech.
 Materiaux & Techniques;Mater. Tech.
 Mathematical Biosciences;Math. Biosci.
+Mathematical Physics, Analysis and Geometry;Math. Phys. Anal. Geom.;;
+Mathematical Population Studies;Math. Popul. Stud.;;
 Mathematische und Naturwissenschaftliche Unterricht;Math. Naturwiss. Unterr.
 Matrix Biology;Matrix Biol.
 Matériaux pour la Carte Géologique de la Suisse, n.s.;Matér. Carte Géol. Suisse
@@ -3001,6 +3566,7 @@ Matériaux pour le levé géobotanique de la Suisse;Matér. levé géobot. Suiss
 Measurement Science & Technology;Meas. Sci. Technol.
 Measurement Science and Technology;Meas. Sci. Technol.
 Mecanique and Industries;Mec. Ind.
+Mechanical Sciences;Mech. Sci.;;
 Mechanics of Advanced Materials and Structures;Mech. Adv. Mater. Struct.
 Mechanics of Composite Materials;Mech. Compos. Mater.
 Mechanics of Composite Materials and Structures;Mech. Compos. Mater. Struct.
@@ -3010,18 +3576,25 @@ Mechanisms of Development;Mech. Dev.
 Meddelelser fra Norsk Institutt for Skogforskning;Medd. Nor. Inst. Skogforsk.
 Mededelingen van de Faculteit Landbouwwetenschappen, Universiteit Gent;Meded. Fac. Landbouwwet., Rijksuniv. Gent
 Mededelingen van de Landbouwhoogeschool te Wageningen;Meded. Landbouwhoogesch. Wagening.
+Medical Gas Research;Med. Gas Res.;;
 Medical Immunology;Med. Immunol.
+Medical Science Monitor Basic Research;Med. Sci. Monit. Basic Res.;;
 Medical Science Research;Med. Sci. Res.
 Medicinal Chemistry;Med. Chem.
 Medicinal Chemistry Research;Med. Chem. Res.
 Medicinal Research Reviews;Med. Res. Rev.
 Mekhanika Kompositnykh Materialov (Zinatne);Mekh. Kompoz. Mater. (Zinatne)
+Memoires de la Societe Royale des Sciences de Liege;Mem. Soc. R. Sci. Liege;;
 Memoirs of the Faculty of Science, Kyushu University, Series C: Chemistry;Mem. Fac. Sci. Kyushu Univ., Ser. C
 Memoirs of the Institute of Scientific and Industrial Research, Osaka University;Mem. Insts. Sci. Ind. Res., Osaka Univ.
+Memorias do Instituto Oswaldo Cruz;Mem. Inst. Oswaldo Cruz;;
 Mendeleev Communications;Mendeleev Commun.
 Merkblatt für den Forstpraktiker Eidg. Anstalt für das forstliche Versuchswesen;Merkbl. Forstprakt. Eidgenöss. Anst. forstl. Vers.wes.
 Merkblatt für die Praxis;Merkbl. Prax.
 Metabolic Engineering;Metab. Eng.
+Metabolic Engineering Communications;Metab. Eng. Commun.;;
+Metabolism Clinical and Experimental;Metab. Clin. Exp.;;
+Metabolism and Nutrition in Oncology;Metab. Nutr. Oncol.;;
 Metabolism, Clinical and Experimental;Metab., Clin. Exp.
 Metabolomics;Metabolomics
 Metal Ions in Biological Systems;Met. Ions Biol. Syst.
@@ -3032,10 +3605,10 @@ Metallofizika (Kiev);Metallofizika (Akad. Nauk Ukr. SSR, Otd. Fiz. Astron.)
 Metallofizika i Noveishie Tekhnologii;Metallofiz. Noveishie Tekhnol.
 Metalloorganicheskaya Khimiya;Metalloorg. Khim.
 Metallovedenie i Termicheskaya Obrabotka Metallov;Metalloved. Term. Obrab. Met.
-Metallurgical and Materials Transactions A: Physical Metallurgy and Materials Science;Metall. Mater. Trans. A
-Metallurgical and Materials Transactions B: Process Metallurgy and Materials Processing Science;Metall. Mater. Trans. B
 Metallurgical Transactions A;Metall. Trans. A
 Metallurgical Transactions B;Metall. Trans. B
+Metallurgical and Materials Transactions A: Physical Metallurgy and Materials Science;Metall. Mater. Trans. A
+Metallurgical and Materials Transactions B: Process Metallurgy and Materials Processing Science;Metall. Mater. Trans. B
 Metally;Metally
 Meteoritics & Planetary Science;Meteorit. Planet. Sci.
 Meteorologische Zeitschrift;Meteorol. Z.
@@ -3043,13 +3616,16 @@ Meteorology and Atmospheric Physics;Meteorol. Atmos. Phys.
 Methods (Oxford, United Kingdom);Methods (Oxford, U. K.)
 Methods (San Diego, CA, United States);Methods (San Diego, CA, U. S.)
 Methods and Findings in Experimental and Clinical Pharmacology;Methods Finds Exp. Clin. Pharmacol.
+Methods in Ecology and Evolution;Methods Ecol. Evol.;;
 Methods in Enzymology;Methods Enzymol.
 Methods of Biochemical Analysis;Methods Biochem. Anal.
 Meylania;Meylania
 Micologia italiana;Micol. ital.
 Microbeam Analysis;Microbeam Anal.
-Microbial and Comparative Genomics;Microb. Comp. Genomics
+Microbial Cell Factories;Microb. Cell Fact.;;
 Microbial Ecology;Microb. Ecol.
+Microbial Informatics and Experimentation;Microb. Inf. Exp.;;
+Microbial and Comparative Genomics;Microb. Comp. Genomics
 Microbiological Research;Microbiol. Res.
 Microbiology (Moscow, Russian Federation)(Translation of Mikrobiologiya);Microbiology (Moscow, Russ. Fed.)
 Microbiology (New York, NY, United States);Microbiology (N. Y., NY, U. S.)
@@ -3060,11 +3636,12 @@ Microchemical Journal;Microchem. J.
 Microchimica Acta;Microchim. Acta
 Microelectronic Engineering;Microelectron. Eng.
 Microelectronics Journal;Microelectron. J.
-Microporous and Mesoporous Materials;Microporous Mesoporous Mater.
+Microgram Journal;Microgram J.;;
 Microporous Materials;Microporous Mater.
+Microporous and Mesoporous Materials;Microporous Mesoporous Mater.
 Microscale Thermophysical Engineering;Microscale Thermophys. Eng.
-Microscopy and Microanalysis;Microsc. Microanal.
 Microscopy Research and Technique;Microsc. Res. Tech.
+Microscopy and Microanalysis;Microsc. Microanal.
 Mikrobiologiya;Mikrobiologiya
 Mikrochimica Acta;Mikrochim. Acta
 Mikroskopie;Mikroskopie
@@ -3072,8 +3649,8 @@ Milchwissenschaft;Milchwissenschaft
 Mine Water and the Environment;Mine Water Environ.
 Mineral Processing and Extractive Metallurgy Review;Miner. Process. Extr. Metall. Rev.
 Mineralium Deposita;Miner. Deposita
-Mineralogical Magazine;Mineral. Mag.
 Mineralogical Magazine;Mineralog. Mag.
+Mineralogical Record;Mineral. Rec.;;
 Mineralogicheskii Zhurnal;Mineral. Zh.
 Mineralogy and Petrology;Mineral. Petrol.
 Minerals & Metallurgical Processing;Miner. Metall. Process.
@@ -3082,6 +3659,7 @@ Mini-Reviews in Medicinal Chemistry;Mini-Rev. Med. Chem.
 Mini-Reviews in Organic Chemistry;Mini-Rev. Org. Chem.
 Mitochondrion;Mitochondrion
 Mitteilungen - Gesellschaft Deutscher Chemiker - Fachgruppe Geschichte der Chemie;Mitt. Gesell. Dtscher. Chem. Fachgruppe Gesch. Chem.
+Mitteilungen Eidg. Anstalt für das forstliche Versuchswesen;Mitt. Eidgenöss. Anst. forstl. Vers.wes.
 Mitteilungen aus der Biologischen Bundesanstalt für Land- und Forstwirtschaft, Berlin-Dahlem;Mitt. Biol. Bundesanst. Land- Forstwirtsch., Berl.-Dahl.
 Mitteilungen aus der Norddeutschen Naturschutzakademie (NNA);Mitt. Norddtsch. Nat.schutzakad.
 Mitteilungen aus der Staatsforstverwaltung Bayerns;Mitt. Staatsforstverwalt. Bayerns
@@ -3091,9 +3669,8 @@ Mitteilungen der Abteilung für Forstliche Biometrie der Universität Freiburg;M
 Mitteilungen der Arbeitsgemeinschaft Geobotanik in Schleswig-Holstein und Hamburg;Mitt. Arb.gem. Geobot. Schlesw.-Holst. Hambg.
 Mitteilungen der Bundesforschungsanstalt für Forst- und Holzwirtschaft;Mitt. Bundesforsch.anst. Forst-  Holzwirtsch.
 Mitteilungen der Deutschen Bodenkundlichen Gesellschaft;Mitt. Dtsch. Bodenkdl. Ges.
-Mitteilungen der Deutschen dendrologischen Gesellschaft;Mitt. Dtsch. dendrol. Ges.
 Mitteilungen der Deutschen Gesellschaft für allgemeine und angewandte Entomologie;Mitt. Dtsch. Ges. allg. angew. Entomol.
-Mitteilungen der deutschen malakozoologischen Gesellschaft;Mitt. dtsch. malakozool. Ges.
+Mitteilungen der Deutschen dendrologischen Gesellschaft;Mitt. Dtsch. dendrol. Ges.
 Mitteilungen der Eidg. Forschungsanstalt für Wald, Schnee und Landschaft;Mitt. Eidgenöss. Forsch.anst. Wald Schnee Landsch.
 Mitteilungen der Entomologischen Gesellschaft Basel;Mitt. Entomol. Ges. Basel
 Mitteilungen der Floristisch-soziologischen Arbeitsgemeinschaft;Mitt. Florist.-soziol. Arb.gem.
@@ -3103,44 +3680,40 @@ Mitteilungen der Geographisch-Ethnographischen Gesellschaft Zürich;Mitt. Geogr.
 Mitteilungen der Gesellschaft für Bibliothekswesen und Dokumentation des Landbaues;Mitt. Ges. Bibl.wes. Dok. Landbaues
 Mitteilungen der Hessischen Landesforstverwaltung;Mitt. Hess. Landesforstverwalt.
 Mitteilungen der Internationalen bodenkundlichen Gesellschaft;Mitt. Int. bodenkdl. Ges.
+Mitteilungen der Naturforschenden Gesellschaft Luzern;Mitt. Nat.forsch. Ges. Luzern
+Mitteilungen der Naturforschenden Gesellschaft Schaffhausen;Mitt. Nat.forsch. Ges. Schaffhausen
 Mitteilungen der Naturforschenden Gesellschaft des Kantons Glarus;Mitt. Nat.forsch. Ges. Kanton Glarus
 Mitteilungen der Naturforschenden Gesellschaft des Kantons Solothurn;Mitt. Nat.forsch. Ges. Kanton Solothurn
 Mitteilungen der Naturforschenden Gesellschaft in Bern;Mitt. Nat.forsch. Ges. Bern
-Mitteilungen der Naturforschenden Gesellschaft Luzern;Mitt. Nat.forsch. Ges. Luzern
-Mitteilungen der Naturforschenden Gesellschaft Schaffhausen;Mitt. Nat.forsch. Ges. Schaffhausen
 Mitteilungen der Naturwissenschaftlichen Gesellschaft Thun;Mitt. Nat.wiss. Ges. Thun
 Mitteilungen der Naturwissenschaftlichen Gesellschaft Winterthur;Mitt. Nat.wiss. Ges. Winterthur
 Mitteilungen der Niedersächsischen forstlichen Versuchsanstalt;Mitt. Niedersächs. forstl. Vers.anst.
 Mitteilungen der Schweizerischen Entomologischen Gesellschaft;Mitt. Schweiz. Entomol. Ges.
 Mitteilungen der Thurgauischen Naturforschenden Gesellschaft;Mitt. Thurgau. Nat.forsch. Ges.
 Mitteilungen der Versuchsanstalt für Wasserbau, Hydrologie und Glaziologie an der Eidg. Technischen Hochschule Zürich;Mitt. Vers.anst. Wasserbau Hydrol. Glaziol. Eidgenöss. Tech. Hochsch. Zür.
+Mitteilungen der deutschen malakozoologischen Gesellschaft;Mitt. dtsch. malakozool. Ges.
 Mitteilungen des Arbeitskreises Wald und Wasser;Mitt. Arb.kr. Wald Wasser
 Mitteilungen des Badischen Landesvereins für Naturkunde und Naturschutz;Mitt. Bad. Landesver. Nat.kd. Nat.schutz
 Mitteilungen des Eidg. Institutes für Schnee- und Lawinenforschung;Mitt. Eidgenöss. Inst. Schnee- Lawinenforsch.
 Mitteilungen des Historischen Vereins des Kantons Schwyz;Mitt. Hist. Ver. Kanton Schwyz
 Mitteilungen des Kuratoriums für Waldarbeit und Forsttechnik;Mitt. Kurat. Waldarb. Forsttech.
 Mitteilungen des Vereins für forstliche Standortskunde und Forstpflanzenzüchtung;Mitt. Ver. forstl. Standortskd. Forstpflanzenzücht.
-Mitteilungen Eidg. Anstalt für das forstliche Versuchswesen;Mitt. Eidgenöss. Anst. forstl. Vers.wes.
+Mitteilungsblatt - Chemische Gesellschaft der Deutschen Demokratischen Republik;Mitteilungsbl. - Chem. Ges. D. D. R.;;
 Modelling and Simulation in Materials Science and Engineering;Modell. Simul. Mater. Sci. Eng.
 Modern Drug Discovery;Mod. Drug Discovery
 Modern Physics Letters A;Mod. Phys. Lett. A
 Modern Physics Letters B;Mod. Phys. Lett. B
 Molecular & Biochemical Parasitology;Mol. Biochem. Parasitol.
-Molecular and Cellular Biochemistry;Mol. Cell. Biochem.
-Molecular and Cellular Biology;Mol. Cell. Biol.
-Molecular and Cellular Endocrinology;Mol. Cell. Endocrinol.
-Molecular and Cellular Neuroscience;Mol. Cell. Neurosci.
-Molecular and Cellular Probes;Mol. Cell. Probes
-Molecular and Cellular Proteomics;Mol. Cell. Proteomics
-Molecular and Supramolecular Photochemistry;Mol. Supramol. Photochem.
+Molecular Astrophysics;Mol. Astrophys.;;
+Molecular BioSystems;Mol. BioSyst.
 Molecular Biology (Moscow, Russian Federation, English Edition) (Translation of Molekulyarnaya Biologiya);Mol. Biol. (Moscow, Russ. Fed., Engl. Ed.)
 Molecular Biology (New York, NY, United States, English Edition);Mol. Biol. (N. Y., NY, U. S., Engl. Ed.)
+Molecular Biology Reports;Mol. Biol. Rep.
 Molecular Biology and Evolution;Mol. Biol. Evol.
 Molecular Biology of the Cell;Mol. Biol. Cell
-Molecular Biology Reports;Mol. Biol. Rep.
-Molecular BioSystems;Mol. BioSyst.
 Molecular Biotechnology;Mol. Biotechnol.
 Molecular Brain Research;Mol. Brain Res.
+Molecular Breeding;Mol. Breed.;;
 Molecular Cancer Research;Mol. Cancer Res.
 Molecular Cancer Therapeutics;Mol. Cancer Ther.
 Molecular Carcinogenesis;Mol. Carcinog.
@@ -3152,25 +3725,38 @@ Molecular Crystals and Liquid Crystals Science and Technology Section C;Mol. Cry
 Molecular Diversity;Mol. Diversity
 Molecular Ecology;Mol. Ecol.
 Molecular Endocrinology;Mol. Endocrinol.
+Molecular Genetics & Genomic Medicine;Mol. Genet. Genomic Med.;;
 Molecular Genetics and Genomics;Mol. Genet. Genomics
 Molecular Genetics and Metabolism;Mol. Genet. Metab.
+Molecular Genetics and Metabolism Reports;Mol. Genet. Metab. Rep.;;
 Molecular Immunology;Mol. Immunol.
 Molecular Interventions;Mol. Interventions
 Molecular Marine Biology and Biotechnology;Mol. Mar. Biol. Biotech.
 Molecular Membrane Biology;Mol. Membr. Biol.
 Molecular Microbiology;Mol. Microbiol.
 Molecular Neurobiology;Mol. Neurobiol.
+Molecular Neurodegeneration;Mol. Neurodegener.;;
 Molecular Nutrition & Food Research;Mol. Nutr. Food Res.
 Molecular Pharmaceutics;Mol. Pharmaceutics
 Molecular Pharmacology;Mol. Pharmacol.
 Molecular Phylogenetics and Evolution;Mol. Phylogenet. Evol.
-Molecular Phylogenetics and Evolution;Mol. Phylogenet. Evol.
 Molecular Physics;Mol. Phys.
+Molecular Plant Pathology;Mol. Plant Pathol;;
 Molecular Plant-Microbe Interactions;Mol. Plant-Microbe Interact.
 Molecular Reproduction and Development;Mol. Reprod. Dev.
 Molecular Screening News;Mol. Screen. News
 Molecular Simulation;Mol. Simul.
 Molecular Therapy;Mol. Ther.
+Molecular Therapy - Methods & Clinical Development;Mol. Ther. Methods Clin. Dev.;;
+Molecular Therapy — Oncolytics;Mol. Ther. Oncolytics;;
+Molecular and Cellular Biochemistry;Mol. Cell. Biochem.
+Molecular and Cellular Biology;Mol. Cell. Biol.
+Molecular and Cellular Endocrinology;Mol. Cell. Endocrinol.
+Molecular and Cellular Neuroscience;Mol. Cell. Neurosci.
+Molecular and Cellular Probes;Mol. Cell. Probes
+Molecular and Cellular Proteomics;Mol. Cell. Proteomics
+Molecular and Cellular Therapies;Mol. Cell. Ther.;;
+Molecular and Supramolecular Photochemistry;Mol. Supramol. Photochem.
 Molecules;Molecules
 Molecules and Cells;Mol. Cells
 Molekulyarnaya Biologiya (Moscow);Mol. Biol. (Moscow)
@@ -3178,49 +3764,69 @@ Molekulyarnaya Genetika, Mikrobiologiya i Virusologiya;Mol. Genet., Mikrobiol. V
 Monatshefte für Chemie;Monatsh. Chem.
 Monatsschrift für das württembergische Forstwesen;Mon.schr. württ. Forstwes.
 Monthly Notices of the Royal Astronomical Society;Mon. Not. R. Astron. Soc.
+Monthly Notices of the Royal Astronomical Society Letters;Mon. Not. R. Astron. Soc. Lett.;;
 Monthly Weather Review;Mon. Weather Rev.
 Monti e boschi;Monti boschi
+Mountain Geologist;Mt. Geol.;;
 Mountain Research and Development;Mt. Res. Dev.
-MRS Bulletin;MRS Bull.
-MRS Internet Journal of Nitride Semiconductor Research;MRS Internet J. Nitride Semicond. Res.
+Movement Ecology;Mov. Ecol.;;
 Mucopolysaccharides Biochimica et Biophysica Acta, Specialized Section on Mucoproteins and Mucopolysaccharides;Biochim. Biophys. Acta, Spec. Sect. Mucoproteins
 Mucosal Immunology;Mucosal Immunol.
+Mull und Abfall;Mull Abfall;;
 Mutagenesis;Mutagenesis
 Mutation Research;Mutat. Res.
+Mutation Research Letters;Mutat. Res. Lett.;;
+Mutation Research, DNA Repair;Mutat. Res. DNA Repair;;
+Mutation Research, DNA Repair Reports;Mutat. Res. DNA Repair Rep.;;
+Mutation Research, DNAging: Genetic Instability and Aging;Mutat. Res. DNAging: Genet. Instab. Aging;;
+Mutation Research, Environmental Mutagenesis and Related Subjects;Mutat. Res. Environ. Mutagen. Relat. Subj.;;
 Mutation Research, Fundamental and Molecular Mechanisms of Mutagenesis;Mutat. Res., Fundam. Mol. Mech. Mutagen.
+Mutation Research, Genetic Toxicology;Mutat. Res. Genet. Toxicol.;;
+Mutation Research, Genetic Toxicology Testing;Mutat. Res. Genet. Toxicol. Test.;;
 Mutation Research, Genetic Toxicology and Environmental Mutagenesis;Mutat. Res., Genet. Toxicol. Environ. Mutagen.
+Mutation Research, Mutation Research Genomics;Mutat. Res. Mutat. Res. Genomics;;
+Mutation Research, Reviews in Genetic Toxicology;Mutat. Res. Rev. Genet. Toxicol.;;
 Mutation Research, Reviews in Mutation Research;Mutat. Res., Rev. Mutat. Res.
 Mycologia;Mycologia
 Mycologia Balcanica;Mycol. Balc.
 Mycologia Helvetica;Mycol. Helv.
 Mycological Progress;Mycol. Prog.
 Mycological Research;Mycol. Res.
-Mycological Research;Mycol. Res.
 Mycotaxon;Mycotaxon
 Mémoires de la Société vaudoise des Sciences Naturelles;Mém. Soc. vaud. Sci. Nat.
-Nachrichten aus Chemie Technik und Laboratorium;Nachr. Chem. Tech. Lab.
-Nachrichten aus der Chemie;Nachr. Chem.
-Nachrichtenblatt des Deutschen Pflanzenschutzdienstes;Nachr.bl. Dtsch. Pflanzenschutzd.
-Nahrung;Nahrung
 NANO;NANO
-Nano Letters;Nano Lett.
-Nano Science and Nano Technology;Nano Sci. Nano Technol.
-NanoBiotechnology;NanoBiotechnology
-Nanomedicine (New York, NY, United States);Nanomedicine (N. Y., NY, U. S.)
-Nanomedicine;Nanomedicine
-Nanoscale and Microscale Thermophysical Engineering;Nanoscale Microscale Thermophys. Eng.
-Nanoscale Research Letters;Nanoscale Res. Lett.
-Nanostructured Materials;Nanostruct. Mater.
 NASA Conference Publication;NASA Conf. Publ.
-National Academy Science Letters (India);Natl. Acad. Sci. Lett. (India)
-National Geographic Magazine;Nat. Geogr. Mag.
-Nationalpark-Forschung in der Schweiz;Natl.park-Forsch. Schweiz
 NATO ASI Series, Series A Life Sciences;NATO ASI Ser., Ser. A
 NATO ASI Series, Series B Physics;NATO ASI Ser., Ser. B
 NATO ASI Series, Series C Mathematical and Physical Sciences;NATO ASI Ser., Ser. C
 NATO ASI Series, Series E Applied Physics;NATO ASI Ser., Ser. E
 NATO ASI Series, Series G Ecological Sciences;NATO ASI Ser., Ser. G
 NATO ASI Series, Series H Cell Biology;NATO ASI Ser., Ser. H
+NDT and E International;NDT and E Int.
+NIST Special Publication;NIST Spec. Publ.
+NMR in Biomedicine;NMR Biomed.
+NNA-Berichte;NNA-Ber.
+NRIAG Journal of Astronomy and Geophysics;NRIAG J. Astron. Geophys.;;
+Nachrichten aus Chemie Technik und Laboratorium;Nachr. Chem. Tech. Lab.
+Nachrichten aus der Chemie;Nachr. Chem.
+Nachrichtenblatt des Deutschen Pflanzenschutzdienstes;Nachr.bl. Dtsch. Pflanzenschutzd.
+Nahrung;Nahrung
+Nano Communication Networks;Nano Commun. Networks;;
+Nano Convergence;Nano Convergence;;
+Nano Letters;Nano Lett.
+Nano Science and Nano Technology;Nano Sci. Nano Technol.
+NanoBiotechnology;NanoBiotechnology
+Nanomaterials and Nanotechnology;Nanomater. Nanotechnol.;;
+Nanomedicine;Nanomedicine
+Nanomedicine (New York, NY, United States);Nanomedicine (N. Y., NY, U. S.)
+Nanoscale Horizons;Nanoscale Horiz.;;
+Nanoscale Research Letters;Nanoscale Res. Lett.
+Nanoscale and Microscale Thermophysical Engineering;Nanoscale Microscale Thermophys. Eng.
+Nanostructured Materials;Nanostruct. Mater.
+National Academy Science Letters (India);Natl. Acad. Sci. Lett. (India)
+National Geographic Magazine;Nat. Geogr. Mag.
+National Science Review;Natl. Sci. Rev.;;
+Nationalpark-Forschung in der Schweiz;Natl.park-Forsch. Schweiz
 Natur und Landschaft;Nat. Landsch.
 Natur und Mensch;Nat. Mensch
 Natur und Museum;Nat. Mus.
@@ -3230,6 +3836,7 @@ Natur- und Landschaftsschutzgebiete Baden-Württembergs;Nat.- Landsch.schutzgeb.
 Natural Areas Journal;Nat. Areas J.
 Natural Hazards;Nat. Hazards
 Natural Hazards and Earth System Sciences;Nat. Hazards Earth Syst. Sci.
+Natural Hazards and Earth System Sciences Discussions;Nat. Hazards Earth Syst. Sci. Discuss.;;
 Natural History;Nat. Hist.
 Natural Product Communications;Nat. Prod. Commun.
 Natural Product Reports;Nat. Prod. Rep.
@@ -3243,20 +3850,18 @@ Natural Products Reports;Nat. Prod. Rep.
 Natural Products Research Part A: Structure and Synthesis;Nat. Prod. Res., Part A
 Natural Products Research Part B: Bioactive Natural Products;Nat. Prod. Res. Part B
 Natural Resource Modeling;Nat. Resour. Model.
+Natural Resources Forum;Nat. Resour. Forum;;
+Natural Resources Journal;Nat. Resour. J.;;
 Natural Structural Biology;Nat. Struct. Biol.
 Natural Toxins;Nat. Toxins
 Naturalist, The;Naturalist
-Naturaliste Canadien (Québec);Nat. Can. (Qué.)
 Naturaliste Canadien;Nat. Can.
+Naturaliste Canadien (Québec);Nat. Can. (Qué.)
 Naturalistes Belges, Les;Nat. Belg.
 Nature (London, United Kingdom);Nature (London, U. K.)
-Nature and environment;Nat. environ.
-Nature and Life in Southeast Asia;Nat. Life Southeast Asia
-Nature and Resources;Nat. Resources
 Nature Biotechnology;Nat. Biotechnol.
 Nature Cell Biology;Nat. Cell Biol.
 Nature Chemical Biology;Nat. Chem. Biol.
-Nature et Progrès;Nat. Prog.
 Nature Genetics;Nat. Genet.
 Nature Immunology;Nat. Immunol.
 Nature Information;Nat. Inf.
@@ -3267,6 +3872,7 @@ Nature Nanotechnology;Nat. Nanotechnol.
 Nature Neuroscience;Nat. Neurosci.
 Nature Photonics;Nat. Photonics
 Nature Physics;Nat. Phys.
+Nature Plants;Nat. Plants;;
 Nature Protocols;Nat. Protoc.
 Nature Reviews Cancer;Nat. Rev. Cancer
 Nature Reviews Drug Discovery;Nat. Rev. Drug Discovery
@@ -3276,6 +3882,10 @@ Nature Reviews Microbiology;Nat. Rev. Microbiol.
 Nature Reviews Molecular Cell Biology;Nat. Rev. Mol. Cell Biol.
 Nature Reviews Neuroscience;Nat. Rev. Neurosci.
 Nature Structural & Molecular Biology;Nat. Struct. Mol. Biol.
+Nature and Life in Southeast Asia;Nat. Life Southeast Asia
+Nature and Resources;Nat. Resources
+Nature and environment;Nat. environ.
+Nature et Progrès;Nat. Prog.
 Nature, London;Nature (London)
 Nature, Paris;Nature (Paris)
 Naturopa;Naturopa
@@ -3288,8 +3898,9 @@ Naturwissenschaften;Naturwissenschaften
 Naturwissenschaften, Die;Naturwissenschaften
 Naturwissenschaftliche Rundschau;Nat.wiss. Rundsch.
 Naunyn-Schmiedeberg's Archives of Pharmacology;Naunyn-Schmiedeberg's Arch. Pharmacol.
-NDT and E International;NDT and E Int.
+Near Surface Geophysics;Near Surf. Geophys.;;
 Nederlands Bosbouw-Tijdschrift;Ned. Bosb.-Tijdschr.
+Nederlands Tijdschrift voor Natuurkunde;Ned. Tijdschr. Natuurkd.;;
 Neftekhimiya;Neftekhimiya
 Neftyanoe Khozyaistvo (Petroleum Industry);Neft. Khoz.
 Nematologia mediterranea;Nematol. mediterr.
@@ -3301,37 +3912,48 @@ Neue Zürcher Zeitung;Neue Zür. Ztg.
 Neues Jahrbuch für Mineralogie, Abhandlungen;Neues Jahrb. Mineral., Abh.
 Neues Jahrbuch für Mineralogie, Monatshefte;Neues Jahrb. Mineral., Monatsh.
 Neujahrsblatt der Lesegesellschaft Wädenswil;Neujahrsbl. Leseges. Wädenswil
-Neujahrsblatt der Naturforschenden Gesellschaft in Zürich;Neujahrsbl. Nat.forsch. Ges. Zür.
 Neujahrsblatt der Naturforschenden Gesellschaft Schaffhausen;Neujahrsbl. Nat.forsch. Ges. Schaffhausen
+Neujahrsblatt der Naturforschenden Gesellschaft in Zürich;Neujahrsbl. Nat.forsch. Ges. Zür.
 Neujahrsbote für das Glarner Hinterland;Neujahrsbote Glarner Hinterland
+Neural Regeneration Research;Neural Regener. Res.;;
+NeuroImmunoModulation;NeuroImmunoModulation
+NeuroMolecular Medicine;NeuroMol. Med.
+Neurobiology of Stress;Neurobiol. Stress;;
 Neurochemical Research;Neurochem. Res.
 Neurochemistry International;Neurochem. Int.
 Neuroendocrinology;Neuroendocrinology
-NeuroImmunoModulation;NeuroImmunoModulation
-NeuroMolecular Medicine;NeuroMol. Med.
 Neuron;Neuron
 Neuropeptides (Amsterdam, Netherlands);Neuropeptides (Amsterdam, Neth.)
 Neuropeptides (Oxford, United Kingdom);Neuropeptides (Oxford, U. K.)
 Neuropharmacology;Neuropharmacology
+Neuropsychiatric Disease and Treatment;Neuropsychiatr. Dis. Treat.;;
+Neuroscience;Neuroscience
 Neuroscience (Oxford, United Kingdom);Neuroscience (Oxford, U. K.)
 Neuroscience (San Diego, CA, United States);Neuroscience (San Diego, CA, U. S.)
-Neuroscience;Neuroscience
 Neuroscience Letters;Neurosci. Lett.
 Neurosignals;Neurosignals
+Neurotoxicity Research;Neurotoxic. Res.;;
 Neurotoxicology and Teratology;Neurotoxicol. Teratol.
 New Comprehensive Biochemistry;New Compr. Biochem.
 New Diamond and Frontier Carbon Technology;New Diamond Front. Carbon Technol.
 New England Journal of Medicine;N. Engl. J. Med.
 New Forests;New For.
+New Horizons in Translational Medicine;New Horiz. Transl. Med.;;
 New Journal of Chemistry;New J. Chem.
 New Journal of Physics;New J. Phys.
-New Phytologist;New Phytol.
+New Microbes New Infections;New Microbes New Infect.;;
+New Negatives in Plant Science;New Negat. Plant Sci.;;
 New Phytologist;New Phytol.
 New Polymeric Materials;New Polym. Mat.
 New Scientist;New Sci.
+New Zealand Geographer;N. Z. Geogr.;;
 New Zealand Journal of Botany;N. Z. J. Bot.
+New Zealand Journal of Crop and Horticultural Science;N. Z. J. Crop Hortic. Sci.;;
 New Zealand Journal of Ecology;N. Z. J. Ecol.
+New Zealand Journal of Forestry Science;N. Z. J. For. Sci.;;
+New Zealand Journal of Geography;N. Z. J. Geogr.;;
 News of Forest History;News For. Hist.
+Newsletters on Stratigraphy;Newsl. Stratigr.;;
 Niedersächsische Akademie der Geowissenschaften Veröffentlichungen;Niedersächs. Akad. Geowiss. Veröff.
 Nihon Reoroji Gakkaishi;Nihon Reoroji Gakkaishi
 Nippon Kagaku Kaishi;Nippon Kagaku Kaishi
@@ -3344,16 +3966,16 @@ Nippon Seramikkusu Kyokai Gakujutsu Ronbunshi;Nippon Seramikkusu Kyokai Gakujuts
 Nippon Shokuhin Kogyo Gakkaishi;Nippon Shokuhin Kogyo Gakkaishi
 Nippon Suisan Gakkaishi;Nippon Suisan Gakkaishi
 Nippon Yakurigaku Zasshi;Nippon Yakurigaku Zasshi
-NIST Special Publication;NIST Spec. Publ.
 Nitric Oxide;Nitric Oxide
-NMR in Biomedicine;NMR Biomed.
-NNA-Berichte;NNA-Ber.
+Nonlinear Analysis: Modeling and Control;Nonlinear Anal. Modell. Control;;
+Nonlinear Processes in Geophysics Discussions;Nonlinear Processes Geophys. Discuss.;;
 Nordic Hydrology;Nord. Hydrol.
 Nordic Journal of Botany;Nord. J. Bot.
 Nordic Pulp & Paper Research Journal;Nord. Pulp Pap. Res. J.
+North American Journal of Fisheries Management;North Am. J. Fish. Manage.;;
+Northern Journal of Applied Forestry;North. J. Appl. For.;;
 Northwest Science;Northwest Sci.
 Nos Oiseaux;Nos Oiseaux
-nostro paese, Il;Nostro paese
 Nota Lepidopterologica;Nota Lepidopterol.
 Note technique Groupement technique forestier;Note tech. Group. tech. for.
 Notes techniques du Centre d’écologie forestière et rurale;Notes tech. Cent. écol. for. rural
@@ -3375,6 +3997,7 @@ Nuclear Physics B, Proceedings Supplements;Nucl. Phys. B, Proc. Suppl.
 Nuclear Science and Engineering;Nucl. Sci. Eng.
 Nuclear Technology;Nucl. Technol.
 Nuclear Tracks and Radiation Measurements;Nucl. Tracks Radiat. Meas.
+Nuclear and Chemical Waste Management;Nucl. Chem. Waste Manage.;;
 Nucleic Acids Research;Nucleic Acids Res.
 Nucleic Acids Research Supplement;Nucleic Acids Res. Suppl.
 Nucleic Acids Symposium Series;Nucleic Acids Symp. Ser.
@@ -3391,7 +4014,8 @@ Nuovo giornale botanico italiano;Nuovo g. bot. ital.
 Nutrition Research (New York, NY, United States);Nutr. Res. (N. Y., NY, U. S.)
 Nutzholzverbrauch in der Schweiz;Nutzholzverbrauch Schweiz
 O'zbekiston Kimyo Jurnali;O'zb. Kim. J.
-O'zbekiston Kimyo Jurnali;O'zb. Kim. J.
+OMICS;OMICS
+Oceanological and Hydrobiological Studies;Oceanol. Hydrobiol. Stud.;;
 Oceanus;Oceanus
 Oecologia;Oecologia
 Oekologia Plantarum;Oekol. Plant.
@@ -3403,9 +4027,9 @@ Oil and Gas Journal;Oil Gas J.
 Oil, Gas (Hamburg, Germany);Oil, Gas (Hamburg, Ger.)
 Oleagineux, Corps Gras, Lipides;Ol. Corps Gras, Lipides
 Oligonucleotides;Oligonucleotides
-OMICS;OMICS
 Oncogene;Oncogene
 Online, ADL-Nachrichten;Online, ADL-Nachr.
+Open Atmospheric Science Journal;Open Atmos. Sci. J.;;
 Open Biochemistry Journal;Open Biochem. J.
 Open Biochemistry Letters;Open Biochem. Lett.
 Open Biomedical Engineering Journal;Open Biomed. Eng. J.
@@ -3415,20 +4039,23 @@ Open Chemical Engineering Journal;Open Chem. Eng. J.
 Open Drug Delivery Journal;Open Drug Delivery J.
 Open Drug Delivery Reviews;Open Drug Delivery Rev.
 Open Food Science Journal;Open Food Sci. J.
+Open Magnetic Resonance Journal;Open Magn. Reson. J.;;
 Open Medicinal Chemistry Journal;Open Med. Chem. J.
 Open Nanoscience Journal;Open Nanosci. J.
 Open Organic Chemistry Reviews;Open Inorg. Chem. Rev.
 Open Physical Chemistry Journal;Open Phys. Chem. J.
 Open Physical Chemistry Reviews;Open Phys. Chem. Rev.
+Open Spectroscopy Journal;Open Spectrosc. J.;;
 Opera Botanica;Opera Bot.
-Optical and Quantum Electronics;Opt. Quantum. Electron.
 Optical Engineering;Opt. Eng.
 Optical Materials;Opt. Mater.
+Optical Nanoscopy;Opt. Nanosc.;;
+Optical and Quantum Electronics;Opt. Quantum. Electron.
 Opticheskii Zhurnal;Opt. Zh.
-Optics and Spectroscopy;Opt. Spectrosc.
 Optics Communications;Opt. Commun.
 Optics Express;Opt. Express
 Optics Letters;Opt. Lett.
+Optics and Spectroscopy;Opt. Spectrosc.
 Optika i Spektroskopiya;Opt. Spektrosk.
 Optiko-Mekhanicheskaya Promyshlennost;Opt.-Mekh. Prom-st.
 Opto-Electronics Review;Opto-Electron. Rev.
@@ -3443,6 +4070,7 @@ Organic Reaction Mechanisms;Org. React. Mech.
 Organic Reactions;Org. React.
 Organic Syntheses;Org. Synth.
 Organisator, Der;Organisator
+Organisms Diversity & Evolution;Org. Divers. Evol.;;
 Organohalogen Compounds;Organohalogen Compd.
 Organometallic Chemistry;Organomet. Chem.
 Organometallics;Organometallics
@@ -3451,7 +4079,6 @@ Origins of Life and Evolution of the Biosphere;Origins Life Evol. Biosphere
 Ornis Fennica;Ornis Fenn.
 Ornis Scandinavica;Ornis Scand.
 Ornithologische Abhandlungen;Ornithol. Abh.
-ornithologische Beobachter, Der;Ornithol. Beob.
 Ornithologische Jahreshefte für Baden-Württemberg;Ornithol. Jahresh. Baden-Württ.
 Oxidation Communications;Oxid. Commun.
 Oxidation of Metals;Oxid. Met.
@@ -3459,12 +4086,32 @@ Oyo Butsuri;Oyo Butsuri
 Oyo Yakuri;Oyo Yakuri
 Ozone Science and Engineering;Ozone Sci. Eng.
 Ozone: Science & Engineering;Ozone: Sci. Eng.
+PBMD-Bulletin;PBMD-Bull.
+PGA Proceedings of the Geologists' Association;PGA Proc. Geol. Assoc.;;
+PLOS Currents: Disasters;PLOS Curr.: Disasters;;
+PLOS Currents: Evidence on Genomic Tests;PLOS Curr.: Evidence Genomic Tests;;
+PLOS Currents: Huntington Disease;PLOS Curr.: Huntington Dis.;;
+PLOS Currents: Muscular Dystrophy;PLOS Curr.: Muscular Dystrophy;;
+PLOS Currents: Outbreaks;PLOS Curr.: Outbreaks;;
+PLOS Currents: Tree of Life;PLOS Curr.: Tree Life;;
+PLOS ONE;PLoS One;;
+PLoS Biology;PLoS Biol.
+PLoS Computational Biology;PLoS Comput. Biol.
+PLoS Genetics;PLoS Genet.
+PLoS One;PLoS One
+PLoS Pathogens;PLoS Pathog.
+PMSE Preprints;PMSE Prepr.
 Pacific Science;Pac. Sci.
+Pacific Science Review;Pac. Sci. Rev.;;
 Pakistan Journal of Science;Pak. J. Sci.
-Pakistan Journal of Scientific and Industrial Research;Pak. J. Sci. Ind. Res.
 Pakistan Journal of Scientific Research;Pak. J. Sci. Res.
+Pakistan Journal of Scientific and Industrial Research;Pak. J. Sci. Ind. Res.
+PalArch's Journal of Vertebrate Palaeontology;PalArch's J. Vertebr. Palaeontol.;;
 Palaeogeography Palaeoclimatology Palaeoecology;Palaeogeogr. Palaeoclimatol. Palaeoecol.
+Palaeontologia Electronica;Palaeontol. Electronica;;
 Paleoclimate Research;Paleoclim. Res.
+Paleontological Bulletin;Paleontol. Bull.;;
+Paleontological Research;Paleontolog. Res.;;
 Paläoklimaforschung;Paläoklimaforschung
 Paper - Geological Survey of Canada;Pap. - Geol. Surv. Can.
 Papers of the Laboratory of Tree Ring Research;Pap. Lab. Tree Ring Res.
@@ -3472,8 +4119,11 @@ Papers of the Michigan Academy of Science, Arts and Letters;Pap. Mich. Acad. Sci
 Particle and Particle Systems Characterization;Part. Part. Syst. Char.
 Particulate Science and Technology;Part. Sci. Technol.
 Pathologie Biologie;Pathol. Biol.
-PBMD-Bulletin;PBMD-Bull.
+Pathology & Oncology Research;Pathol. Oncol. Res.;;
+Pattern Recognition in Physics;Pattern Recognit. Phys.;;
 Pediatric Research;Pediatr. Res.
+PeerJ;PeerJ;;
+PeerJ Computer Science;PeerJ Comput. Sci.;;
 Peptide Chemistry;Pept. Chem.
 Peptide Science;Pept. Sci.
 Peptides (Amsterdam, Netherlands);Peptides (Amsterdam, Neth.)
@@ -3483,6 +4133,8 @@ Permafrost and Periglacial Processes;Permafrost Periglacial Process.
 Personality and Individual Differences;Pers. Individ. Differ.
 Perspectives in Drug Discovery and Design;Perspect. Drug Discovery Des.
 Perspectives in Plant Ecology, Evolution and Systematics;Perspect. Plant Ecol. Evol. Syst.
+Perspectives in Science;Perspect. Sci.;;
+Pertanika Journal of Tropical Agricultural Science;Pertanika J. Trop. Agric. Sci.;;
 Pervasive Computing;Pervasive Comput.
 Pesquisa Agropecuária Brasileira;Pesqui. Agropecu. Bras.
 Pest Management Science;Pest Manage. Sci.
@@ -3493,18 +4145,25 @@ Pesticides;Pesticides
 Petroleum Science and Technology;Pet. Sci. Technol.
 Pflanzenschutz-Nachrichten Bayer;Pflanzenschutz-Nachr. Bayer
 Pfluegers Archiv;Pfluegers Arch.
-Pharmaceutical and Pharmacological Letters;Pharm. Pharmacol. Lett.
 Pharmaceutical Chemistry Journal;Pharm. Chem. J.
 Pharmaceutical Development and Technology;Pharm. Dev. Technol.
+Pharmaceutical Methods;Pharm. Methods;;
 Pharmaceutical Research;Pharm. Res.
 Pharmaceutical Technology;Pharm. Technol.
+Pharmaceutical and Pharmacological Letters;Pharm. Pharmacol. Lett.
 Pharmacochemistry Library;Pharmacochem. Libr.
 Pharmacogenetics and Genomics;Pharmacogenet. Genomics
 Pharmacogenomics Journal;Pharmacogenomics J.
+Pharmacogenomics and Personalized Medicine;Pharmacogenomics Pers. Med.;;
 Pharmacological Research;Pharmacol. Res.
-Pharmacology & Therapeutics;Pharmacol. Ther.
-Pharmacology & Toxicology (Copenhagen);Pharmacol. Toxicol. (Copenhagen)
 Pharmacology;Pharmacology
+Pharmacology & Therapeutics;Pharmacol. Ther.
+Pharmacology & Therapeutics, Part A: Chemotherapy, Toxicology and Metabolic Inhibitors;Pharmacol. Ther., Part A;;
+Pharmacology & Therapeutics, Part B: General & Systematic Pharmacology;Pharmacol. Ther., Part B;;
+Pharmacology & Therapeutics, Part C: Clinical Pharmacology and Therapeutics;Pharmacol. Ther., Part C;;
+Pharmacology & Toxicology (Copenhagen);Pharmacol. Toxicol. (Copenhagen)
+Pharmacology Biochemistry and Behavior.;Pharmacol. Biochem. Behav;;
+Pharmacology Research & Perspectives;Pharmacol. Res. Perspect.;;
 Pharmacology, Biochemistry and Behavior;Pharmacol., Biochem. Behav.
 Pharmacy and Pharmacology Communications;Pharm. Pharmacol. Commun.
 Pharmazie;Pharmazie
@@ -3517,8 +4176,8 @@ Philosophical Magazine B;Philos. Mag. B
 Philosophical Magazine B: Physics of Condensed Matter: Statistical Mechanics, Electronic, Optical and Magnetic Properties;Philos. Mag. B
 Philosophical Magazine B: Physics of Condensed Matter: Structural, Electronic, Optical and Magnetic Properties;Philos. Mag. B
 Philosophical Magazine Letters;Philos. Mag. Lett.
-Philosophical Transactions of the Royal Society of London;Philos. Trans. R. Soc. Lond.
 Philosophical Transactions of the Royal Society A: Mathematical, Physical and Engineering Sciences;Philos. Trans. Royal Soc. A
+Philosophical Transactions of the Royal Society of London;Philos. Trans. R. Soc. Lond.
 Philosophical Transactions of the Royal Society of London, Series A;Philos. Trans. R. Soc. London, Ser. A
 Philosophical Transactions of the Royal Society of London, Series B;Philos. Trans. R. Soc. London, Ser. B
 Phosphorus, Sulfur and Silicon and the Related Elements;Phosphorus, Sulfur Silicon Relat. Elem.
@@ -3537,70 +4196,71 @@ Physica Scripta;Phys. Scr.
 Physica Scripta, T;Phys. Scr., T
 Physica Status Solidi A: Applications and Materials Science;Phys. Status Solidi A
 Physica Status Solidi B: Basic Solid State Physics;Phys. Status Solidi B
+Physica Status Solidi C: Conferences and Critical Reviews;Phys. Status Solidi C;;
 Physica Status Solidi C: Current Topics in Solid State Physics;Phys. Status Solidi C
 Physica Status Solidi RRL: Rapid Research Letters;Phys. Status Solidi RRL
 Physical Biology;Phys. Biol.
 Physical Chemistry Chemical Physics;Phys. Chem. Chem. Phys.
 Physical Geography;Phys. Geogr.
 Physical Review A;Phys. Rev. A
-Physical Review A: Atomic, Molecular, and Optical Physics;Phys. Rev. A: At., Mol., Opt. Phys.
+Physical Review A: Atomic, Molecular, and Optical Physics;Phys. Rev. A: At. Mol. Opt. Phys.
 Physical Review B;Phys. Rev. B
 Physical Review B: Condensed Matter and Materials Physics;Phys. Rev. B: Condens. Matter Mater. Phys.
 Physical Review C: Nuclear Physics;Phys. Rev. C: Nucl. Phys.
 Physical Review D: Particles, Fields, Gravitation, and Cosmology;Phys. Rev. D: Part., Fields, Gravitation, Cosmol.
 Physical Review E: Statistical, Nonlinear, and Soft Matter Physics;Phys. Rev. E: Stat., Nonlinear, Soft Matter Phys.
 Physical Review Letters;Phys. Rev. Lett.
+Physics Education;Phys. Educ.
+Physics Letters A;Phys. Lett. A
+Physics Letters B;Phys. Lett. B
+Physics Reports;Phys. Rep.
+Physics Teacher;Phys. Teach.
+Physics World;Phys. World
 Physics and Chemistry of Glasses;Phys. Chem. Glasses
 Physics and Chemistry of Glasses: European Journal of Glass Science and Technology, Part B;Phys. Chem. Glasses: Eur. J. Glass Sci. Technol., Part B
 Physics and Chemistry of Liquids;Phys. Chem. Liq.
 Physics and Chemistry of Minerals;Phys. Chem. Miner.
-Physics Education;Phys. Educ.
 Physics in Medicine & Biology;Phys. Med. Biol.
 Physics in Technology;Phys. Technol.
-Physics Letters A;Phys. Lett. A
-Physics Letters B;Phys. Lett. B
 Physics of Atomic Nuclei;Phys. At. Nucl.
 Physics of Fluids;Phys. Fluids
 Physics of Fluids A;Phys. Fluids A
 Physics of Fluids A: Fluid Dynamics;Phys. Fluids A
 Physics of Fluids B;Phys. Fluids B
 Physics of Fluids B: Plasma Physics;Phys. Fluids B
+Physics of Life Reviews;Phys. Life Rev.;;
 Physics of Plasmas;Phys. Plasmas
+Physics of the Dark Universe;Phys. Dark Universe;;
 Physics of the Solid State;Phys. Solid State
-Physics Reports;Phys. Rep.
-Physics Teacher;Phys. Teach.
-Physics World;Phys. World
-Physics World;Phys. World
 Physics-Uspekhi;Phys. Usp.
 Physik in Unserer Zeit;Phys. Unserer Zeit
 Physikalische Blätter;Phys. Bl.
 Physikalishce Zeitschrift;Phys. Z.
 Physiologia Plantarum;Physiol. Plant.
-Physiological and Biochemical Zoology;Physiol. Biochem. Zool.
-Physiological and Molecular Plant Pathology;Physiol. Mol. Plant Pathol.
 Physiological Chemistry and Physics and Medical NMR;Physiol. Chem. Phys. Med. NMR
 Physiological Measurement;Physiol. Meas.
 Physiological Plant Pathology;Physiol. Plant Pathol.
+Physiological and Biochemical Zoology;Physiol. Biochem. Zool.
+Physiological and Molecular Plant Pathology;Physiol. Mol. Plant Pathol.
 Physiology & Behavior;Physiol. Behav.
 Physiology and Behavior;Physiol. Behav.
 Physische Geographie;Phys. Geogr.
 Phytochemical Analysis;Phytochem. Anal.
-Phytochemistry (Elsevier);Phytochemistry (Elsevier)
 Phytochemistry;Phytochemistry
+Phytochemistry (Elsevier);Phytochemistry (Elsevier)
 Phytochemistry Reviews;Phytochem. Rev.
 Phytocoenologia;Phytocoenologia
 Phyton;Phyton
 Phytopathologische Zeitschrift;Phytopathol. Z.
 Phytopathology;Phytopathology
 Pigment & Resin Technology;Pigm. Resin Technol.
-Pigment Cell Research;Pigm. Cell Res.
+Pigment Cell Research;Pigment Cell Res.
 Pis'ma v Astronomicheskii Zhurnal;Pis'ma Astron. Zh.
 Pis'ma v Zhurnal Eksperimental'noi i Teoreticheskoi Fiziki;Pis'ma Zh. Eksp. Teor. Fiz.
 Pis'ma v Zhurnal Tekhnicheskoi Fiziki;Pis'ma Zh. Tekh. Fiz.
 Pishchevaya Promyshlennost (Moscow);Pishch. Prom-st. (Moscow)
 Plan;Plan
-Plant and Cell Physiology;Plant Cell Physiol.
-Plant and Soil;Plant Soil
+Plankton and Benthos Research;Plankton Benthos Res.;;
 Plant Biology;Plant Biol.
 Plant Cell;Plant Cell
 Plant Cell Reports;Plant Cell Rep.
@@ -3616,8 +4276,11 @@ Plant Physiology and Biochemistry (Amsterdam, Netherlands);Plant Physiol. Bioche
 Plant Physiology and Biochemistry (Issy les Moulineaux, France);Plant Physiol. Biochem. (Issy les Moulineaux, Fr.)
 Plant Science (Amsterdam, Netherlands);Plant Sci. (Amsterdam, Neth.)
 Plant Science (Limerick, Ireland);Plant Sci. (Limerick, Irel.)
+Plant Signaling & Behavior;Plant Signaling Behav.;;
+Plant Species Biology;Plant Species Biol.;;
 Plant Systematics and Evolution;Plant Syst. Evol.
-Plant, Cell and Environment;Plant Cell Environ.
+Plant and Cell Physiology;Plant Cell Physiol.
+Plant and Soil;Plant Soil
 Plant, Cell and Environment;Plant, Cell Environ.
 Planta;Planta
 Planta Medica;Planta Med.
@@ -3639,24 +4302,22 @@ Plastics, Rubber and Composites;Plast., Rubber Compos.
 Platelets;Platelets
 Plating and Surface Finishing;Plat. Surf. Finish.
 Platinum Metals Review;Platinum Met. Rev.
-PLoS Biology;PLoS Biol.
-PLoS Computational Biology;PLoS Comput. Biol.
-PLoS Genetics;PLoS Genet.
-PLoS One;PLoS One
-PLoS Pathogens;PLoS Pathog.
-PMSE Preprints;PMSE Prepr.
 Pochvovedenie;Pochvovedenie
+Poggendorff's Annalen der Physik;Poggendorff's Ann. Phys.;;
+Polar Biology;Polar Biol.;;
+Polar Geography;Polar Geogr.;;
 Polar Research;Polar Res.
 Polimery (Warsaw);Polimery (Warsaw)
 Polish Journal of Chemistry;Pol. J. Chem.
+Polish Journal of Natural Science;Pol. J. Nat. Sci.;;
 Polish Journal of Pharmacology and Pharmacy;Pol. J. Pharmacol. Pharm.
 Politische Ökologie;Polit. Ökol.
 Pollen et Spores;Pollen Spores
 Pollution Atmospherique;Pollut. Atmos.
 Polycyclic Aromatic Compounds;Polycyclic Aromat. Compd.
 Polyhedron;Polyhedron
-Polymer (Korea);Polymer (Korea)
 Polymer;Polymer
+Polymer (Korea);Polymer (Korea)
 Polymer Bulletin (Berlin);Polym. Bull. (Berlin)
 Polymer Bulletin (Heidelberg, Germany);Polym. Bull. (Heidelberg, Ger.)
 Polymer Composites;Polym. Compos.
@@ -3675,6 +4336,7 @@ Polymer-Plastics Technology and Engineering;Polym.-Plast. Technol. Eng.
 Polymeric Materials Science and Engineering;Polym. Mater. Sci. Eng.
 Polymers & Polymer Composites;Polym. Polym. Compos.
 Polymers for Advanced Technologies;Polym. Adv. Technol.
+Polymers from Renewable Resources;Polym. Renewable Resour.;;
 Poroshkovaya Metallurgiya (Kiev);Poroshk. Metall. (Kiev)
 Postepy Biochemii;Postepy Biochem.
 Poultry Science;Poult. Sci.
@@ -3683,14 +4345,15 @@ Powder Diffraction;Powder Diffr.
 Powder Metallurgy;Powder Metall.
 Powder Metallurgy and Metal Ceramics;Powder Metall. Met. Ceram.
 Powder Technology;Powder Technol.
+Power Engineer;Power Eng.;;
 Prace Naukowe Instytutu Technologii Nieorganicznej i Nawozow Mineralnych Politechniki Wroclawskiej;Pr. Nauk Inst. Technol. Nieorg. Nawozow Miner. Politech. Wroclaw.
 Practical Proteomics;Pract. Proteomics
 Practical Spectroscopy;Pract. Spectrosc.
-praktische Forstwirt für die Schweiz, Der;Prakt. Forstwirt Schweiz
 Praktische Metallographie;Prakt. Metallogr.
 Pramana;Pramana
 Praxis der Naturwissenschaften, Chemie in der Schule;Prax. Naturwiss. Chem. Sch.
 Precambrian Research;Precambrian Res.
+Precision Agriculture;Precis. Agric.;;
 Preparative Biochemistry & Biotechnology;Prep. Biochem. Biotechnol.
 Preprints - American Chemical Society, Division of Petroleum Chemistry;Prepr. - Am. Chem. Soc., Div. Pet. Chem.
 Preprints of Extended Abstracts presented at the ACS National Meeting, American Chemical Society, Division of Environmental Chemistry;Prepr. Ext. Abstr. ACS Natl. Meet., Am. Chem. Soc., Div. Environ. Chem.
@@ -3700,16 +4363,27 @@ Pribory i Tekhnika Eksperimenta;Prib. Tekh. Eksp.
 Prikladnaya Biokhimiya i Mikrobiologiya;Prikl. Biokhim. Mikrobiol.
 Priroda (Moscow);Priroda (Moscow)
 Problemy Prochnosti;Probl. Prochn.
+Procedia Chemistry;Procedia Chem.;;
+Procedia Computer Science;Procedia Comput. Sci.;;
+Procedia Earth and Planetary Science;Procedia Earth Planet. Sci.;;
+Procedia Engineering;Procedia Eng.;;
+Procedia Environmental Sciences;Procedia Environ. Sci.;;
+Procedia Food Science;Procedia Food Sci.;;
+Procedia Technology;Procedia Technol.;;
 Proceedings - Electrochemical Society;Proc. - Electrochem. Soc.
 Proceedings - Electronic Components & Technology Conference;Proc. - Electron. Compon. Conf.
 Proceedings - Indian Academy of Sciences, Chemical Sciences;Proc. - Indian Acad. Sci., Chem. Sci.
 Proceedings of SPIE - The International Society for Optical Engineering;Proc. SPIE-Int. Soc. Opt. Eng.
 Proceedings of the AESF Annual Technical Conference;Proc. - AESF Annu. Tech. Conf.
 Proceedings of the American Power Conference;Proc. Am. Power Conf.
+Proceedings of the British Institution of Radio Engineers;Proc. Br. Inst. Radio Eng.;;
 Proceedings of the Estonian Academy of Sciences, Chemistry;Proc. Est. Acad. Sci., Chem.
 Proceedings of the IEEE;Proc. IEEE
 Proceedings of the Industrial Waste Conference;Proc. Ind. Waste Conf.
+Proceedings of the Institution of Electrical Engineers;Proc. Inst. Electr. Eng.;;
+Proceedings of the Institution of Electronic and Radio Engineers;Proc. Inst. Electron. Radio Eng.;;
 Proceedings of the Institution of Mechanical Engineers, IMechE Conference;Proc. Inst. Mech. Eng., IMechE Conf.
+Proceedings of the International Association of Hydrological Sciences;Proc. Int. Assoc. Hydrol. Sci.;;
 Proceedings of the International Conference on Lasers;Proc. Int. Conf. Lasers
 Proceedings of the International Congress of Ecology;Proc. Int. Congr. Ecol.
 Proceedings of the International Power Sources Symposium;Proc. Int. Power Sources Symp.
@@ -3724,42 +4398,48 @@ Proceedings of the National Academy of Sciences, India, Section A: Physical Scie
 Proceedings of the Physical Society of London;Proc. Phys. Soc. London
 Proceedings of the Physical Society. Section A;Proc. Phys. Soc. London, Sect. A
 Proceedings of the Physical Society. Section B;Proc. Phys. Soc. London, Sect. B
+Proceedings of the Prehistoric Society;Proc. Prehist. Soc;;
 Proceedings of the Royal Irish Academy;Proc. R. Ir. Acad.
 Proceedings of the Royal Society of London. Series A;Proc. R. Soc. London, Ser. A.
 Proceedings of the Royal Society of London. Series A - Mathematical and Physical Sciences;Proc. R. Soc. London, Ser. A Math Phys. Sci.
+Proceedings of the Royal Society of London. Series A, Containing Papers of a Mathematical and Physical Character;Proc. R. Soc. London, Ser. A.
 Proceedings of the Royal Society of London. Series B;Proc. R. Soc. London, Ser. B
 Proceedings of the Royal Society of London. Series B: Biological Sciences;Proc. R. Soc. London, Ser. B
-Proceedings of the Royal Society of London. Series A, Containing Papers of a Mathematical and Physical Character;Proc. R. Soc. London, Ser. A.
+Proceedings of the SPI Annual Technical/Marketing Conference;Proc. SPI Annu. Tech./Mark. Conf.
 Proceedings of the Society for Experimental Biology and Medicine;Proc. Soc. Exp. Biol. Med.
 Proceedings of the Soil Science Society of America;Proc. Soil Sci. Soc. Am.
-Proceedings of the SPI Annual Technical/Marketing Conference;Proc. SPI Annu. Tech./Mark. Conf.
 Proceedings of the Western Pharmacology Society;Proc. West. Pharmacol. Soc.
 Proceedings of the Workshop on Vitamin D;Proc. Workshop Vitam. D
 Proceedings of the Zoological Society of London;Proc. Zool. Soc. Lond.
 Process Biochemistry (Amsterdam, Netherlands);Process Biochem. (Amsterdam, Neth.)
 Process Biochemistry (Oxford, United Kingdom);Process Biochem. (Oxford, U. K.)
 Process Control and Quality;Process Control Qual.
-Process Safety and Environmental Protection;Process Saf. Environ. Prot.
 Process Safety Progress;Process Saf. Prog.
+Process Safety and Environmental Protection;Process Saf. Environ. Prot.
 Produktion von Leiterplatten und Systemen;Prod. Leiterplatten Sys.
 Professional Geographer;Prof. Geogr.
 Progress in Astronautics and Aeronautics;Prog. Astronaut. Aeronaut.
+Progress in Biomaterials;Prog. Biomater.;;
 Progress in Biometeorology;Prog. Biometeorol.
 Progress in Biophysics and Molecular biology;Prog. Biophys. Mol. Biol.
 Progress in Biotechnology;Prog. Biotechnol.
 Progress in Botany;Prog. Bot.
 Progress in Brain Research;Prog. Brain Res.
 Progress in Clinical and Biological Research;Prog. Clin. Biol. Res.
+Progress in Colloid & Polymer Science;Prog. Colloid Polym. Sci.;;
 Progress in Colloid and Polymer Science;Prog. Colloid Polym. Sci.
 Progress in Crystal Growth and Characterization of Materials;Prog. Cryst. Growth Charact. Mater.
+Progress in Earth and Planetary Science;Prog. Earth Planet. Sci.;;
 Progress in Energy and Combustion Science;Prog. Energy Combust. Sci.
 Progress in Heterocyclic Chemistry;Prog. Heterocycl. Chem.
+Progress in Industrial Ecology;Prog. Ind. Ecol.;;
 Progress in Industrial Microbiology;Prog. Ind. Microbiol.
 Progress in Inorganic Chemistry;Prog. Inorg. Chem.
 Progress in Leukocyte Biology;Prog. Leukocyte Biol.
 Progress in Lipid Research;Prog. Lipid Res.
 Progress in Materials Science;Prog. Mater Sci.
 Progress in Medicinal Chemistry;Prog. Med. Chem.
+Progress in Neuro-Psychopharmacology & Biological Psychiatry;Prog. Neuro-Psychopharmacol. Biol. Psychiatry;;
 Progress in Nuclear Energy;Prog. Nucl. Energy
 Progress in Nuclear Magnetic Resonance Spectroscopy;Prog. Nucl. Magn. Reson. Spectrosc.
 Progress in Nucleic Acid Research and Molecular Biology;Prog. Nucleic Acid Res. Mol. Biol.
@@ -3770,14 +4450,15 @@ Progress in Physical Organic Chemistry;Prog. Phys. Org. Chem.
 Progress in Polymer Science;Prog. Polym. Sci.
 Progress in Reaction Kinetics;Prog. React. Kinet.
 Progress in Reaction Kinetics and Mechanism;Prog. React. Kinet. Mech.
+Progress in Rubber, Plastics and Recycling Technology;Prog. Rubber Plast. Recycl. Technol.;;
 Progress in Solid State Chemistry;Prog. Solid State Chem.
 Progress in Surface Science;Prog. Surf. Sci.
 Progress in the Chemistry of Organic Natural Products;Prog. Chem. Org. Nat. Prod.
 Progress of Theoretical Physics;Prog. Theor. Phys.
 Progressus Rei Botanicae;Progress. Rei Bot.
 Propellants, Explosives, Pyrotechnics;Propellants, Explos., Pyrotech.
-Prostaglandins & Other Lipid Mediators;Prostaglandins Other Lipid Mediators
 Prostaglandins;Prostaglandins
+Prostaglandins & Other Lipid Mediators;Prostaglandins Other Lipid Mediators
 Prostaglandins, Leukotrienes and Essential Fatty Acids;Prostaglandins, Leukotrienes Essent. Fatty Acids
 Protection de la nature;Prot. nat.
 Protection of Metals;Prot. Met.
@@ -3787,9 +4468,11 @@ Protein Engineering, Design & Selection;Protein Eng., Des. Sel.
 Protein Expression and Purification;Protein Expression Purif.
 Protein Journal;Protein J.
 Protein Science;Protein Sci.
+Protein and Peptide Letters;Protein Pept. Lett.;;
 Proteins: Structure, Function, and Bioinformatics;Proteins: Struct., Funct., Bioinf.
 Proteins: Structure, Function, and Genetics;Proteins: Struct., Funct., Genet.
 Proteomics;Proteomics
+Proteomics - Clinical Applications;Proteomics Clin. Appl.;;
 Proteomics: Clinical Applications;Proteomics: Clin. Appl.
 Protides of the Biological Fluids;Protides Biol. Fluids
 Protist;Protist
@@ -3797,6 +4480,8 @@ Przemysl Chemiczny;Przem. Chem.
 Psychopharmacology (Berlin, Germany);Psychopharmacology (Berlin, Ger.)
 Pteridines;Pteridines
 Pubblicazioni del Centro di sperimentazione agricola e forestale;Pubbl. Cent. sper. agric. for.
+Publications of the Astronomical Society of Australia;Publ. Astron. Soc. Aust.;;
+Publications of the Astronomical Society of Japan;Publ. Astron. Soc. Jpn.;;
 Pulmonary Pharmacology & Therapeutics;Pulm. Pharmacol. Ther.
 Pure and Applied Chemistry;Pure Appl. Chem.
 Pure and Applied Optics;Pure Appl. Opt.
@@ -3805,36 +4490,44 @@ Pyrethrum Post;Pyrethrum Post
 QSAR & Combinatorial Science;QSAR Comb. Sci.
 Quaderni dell'Ingegnere Chimico Italiano;Quad. Ing. Chim. Ital.
 Quantitative Structure-Activity Relationships;Quant. Struct.-Act. Relat.
-Quantum and Semiclassical Optics;Quantum Semiclassical Opt.
 Quantum Electronics;Quantum Electron.
 Quantum Optics;Quantum Opt.
+Quantum and Semiclassical Optics;Quantum Semiclassical Opt.
 Quarterly Bulletin of the International Association of Agricultural Information Specialists;Q. Bull. Int. Assoc. Agric. Inf. Spec.
 Quarterly Journal of Forestry;Q. J. For.
+Quarterly Journal of International Agriculture;Q. J. Int. Agric.;;
 Quarterly Review of Biology;Q. Rev. Biol.
 Quarterly Reviews of Biophysics;Q. Rev. Biophys.
 Quarternary International;Quart. Int.
 Quaternary Research;Quat. Res.
 Quaternary Science Reviews;Quat. Sci. Rev.
 Quimica Analitica;Quim. Anal. (Barcelona)
-Quimica no Brasil;Quim. Bras.
 Quimica Nova;Quim. Nova
+Quimica no Brasil;Quim. Bras.
+RAPRA Review Reports;Rapra Rev. Rep.
+REFA-Nachrichten;REFA-Nachr.
+RNA;RNA
+RNA Biology;RNA Biol.
 Radiation Effects and Defects in Solids;Radiat. Eff. Defects Solids
 Radiation Measurements;Radiat. Meas.
 Radiation Physics and Chemistry;Radiat. Phys. Chem.
 Radiation Protection Dosimetry;Radiat. Prot. Dosim.
 Radiation Research;Radiat. Res.
 Radiatsionnaya Bezopasnost i Zashchita AES;Radiats. Bezop. Zashch. AES
+Radio and Electronic Engineer;Radio Electron. Eng.;;
 Radiobiologiya;Radiobiologiya
 Radiocarbon;Radiocarbon
 Radiochemistry (Moscow, Russian Federation)(Translation of Radiokhimiya);Radiochemistry (Moscow, Russ. Fed.)
 Radiochemistry (New York, NY, United States);Radiochemistry (N. Y., NY, U. S.)
 Radiochimica Acta;Radiochim. Acta
 Radiokhimiya;Radiokhimiya
+Radiology of Infectious Diseases;Radiol. Infect. Dis.;;
 Radioprotection;Radioprotection
 Radiotekhnika i Elektronika (Moscow);Radiotekh. Elektron. (Moscow)
+Rangeland Ecology & Management;Rangeland Ecol. Manage.;;
+Rangeland Journal;Rangeland J.;;
 Ranliao Huaxue Xuebao;Ranliao Huaxue Xuebao
 Rapid Communications in Mass Spectrometry;Rapid Commun. Mass Spectrom.
-RAPRA Review Reports;Rapra Rev. Rep.
 Rare Metals (Beijing, China);Rare Met. (Beijing, China)
 Rasplavy;Rasplavy
 Raumforschung und Raumordnung;Raumforsch. Raumordn.
@@ -3845,8 +4538,8 @@ Reactive Polymers;React. Polym.
 Recent Patents on Anti-Cancer Drug Discovery;Recent Pat. Anti-Cancer Drug Discovery
 Recent Patents on Anti-Infective Drug Discovery;Recent Pat. Anti-Infect. Drug Discovery
 Recent Patents on Biotechnology;Recent Pat. Biotechnol.
-Recent Patents on Cardiovascular Drug Discovery;Recent Pat. Cardiovasc. Drug Discovery
 Recent Patents on CNS Drug Discovery;Recent Pat. CNS Drug Discovery
+Recent Patents on Cardiovascular Drug Discovery;Recent Pat. Cardiovasc. Drug Discovery
 Recent Patents on DNA & Gene Sequences;Recent Pat. DNA Gene Sequences
 Recent Patents on Drug Delivery & Formulation;Recent Pat. Drug Delivery Formulation
 Recent Patents on Endocrine, Metabolic & Immune Drug Discovery;Recent Pat. Endocr., Metab. Immune Drug Discovery
@@ -3855,18 +4548,22 @@ Recent Patents on Nanotechnology;Recent Pat. Nanotechnol.
 Recent Progress in Hormone Research;Recent Prog. Horm. Res.
 Receptors and Channels;Recept. Channels
 Recherche, La;Recherche
+Records of the Australian Museum;Rec. Aust. Mus.;;
 Recueil des Travaux Chimiques des Pays-Bas;Recl. Trav. Chim. Pays-Bas
 Recueil des Travaux Chimiques des Pays-Bas Journal of the Royal Netherlands Chemical Society;Recl. Trav. Chim. Pays-Bas
-REFA-Nachrichten;REFA-Nachr.
 Refractories and Industrial Ceramics;Refract. Ind. Ceram
+Regenerative Biomaterials;Regener. Biomater.;;
+Regenerative Engineering and Translational Medicine;Regener. Eng. Transl. Med.;;
 Regio Basiliensis;Reg. Basil.
 Regional Environmental Change;Reg. Environ. Change
 Regulatory Peptides;Regul. Pept.
 Regulatory Toxicology and Pharmacology;Regul. Toxicol. Pharm.
 Reinforced Plastics;Reinf. Plast.
 Reinforced Plastics and Composites World;Reinf. Plast. Compos. World
-Remote Sensing of Environment;Remote Sens. Environ.
+Reliability Engineering;Reliab. Eng.;;
 Remote Sensing Series;Remote Sens. Ser.
+Remote Sensing of Environment;Remote Sens. Environ.
+Renewable Resources Journal;Renewable Resour. J.;;
 Rengong Jingti Xuebao;Rengong Jingti Xuebao
 Reports on Progress in Physics;Rep. Prog. Phys.
 Reproduction (Bristol, United Kingdom);Reproduction (Bristol, U. K.)
@@ -3878,13 +4575,17 @@ Research Communications in Chemical Pathology and Pharmacology;Res. Commun. Chem
 Research Communications in Molecular Pathology and Pharmacology;Res. Commun. Mol. Pathol. Pharmacol.
 Research Communications in Pharmacology and Toxicology;Res. Commun. Pharmacol. Toxicol.
 Research Disclosure;Res. Discl.
+Research Integrity and Peer Review;Res. Integrity Peer Rev.;;
+Research Journal of Chemistry and Environment;Res. J. Chem. Environ;;
+Research Paper USDA Forest Service;Res. Pap. USDA For. Serv.
 Research in Economic Anthropology;Res. Econ. Anthropol.
 Research in Life Sciences;Res. Life Sci.
 Research in Microbiology;Res. Microbiol.
 Research in Veterinary Science;Res. Vet. Sci.
 Research on Chemical Intermediates;Res. Chem. Intermed.
-Research Paper USDA Forest Service;Res. Pap. USDA For. Serv.
+Resource Engineering and Technology for Sustainable World;Resour. Eng. Technol. Sustainable World;;
 Restoration Ecology;Restor. Ecol.
+Results in Physics;Results Phys.;;
 Review of Palaeobotany and Palynology;Rev. Palaeobot. Palynol.
 Review of Physics in Technology;Rev. Phys. Technol.
 Review of Plant Pathology;Rev. Plant Pathol.
@@ -3893,45 +4594,53 @@ Reviews in Analytical Chemistry;Rev. Anal. Chem.
 Reviews in Chemical Engineering;Rev. Chem. Eng.
 Reviews in Computational Chemistry;Rev. Comput. Chem.
 Reviews in Conservation;Rev. Conserv.
+Reviews in Fish Biology and Fisheries;Rev. Fish Biol. Fish.;;
 Reviews in Inorganic Chemistry;Rev. Inorg. Chem.
 Reviews in Molecular Biotechnology;Rev. Mol. Biotechnol.
+Reviews in Physics;Rev. Phys.;;
 Reviews of Environment Contamination and Toxicology;Rev. Environ. Contam. Toxicol.
 Reviews of Geophysics;Rev. Geophys.
 Reviews of Physiology Biochemistry and Pharmacology;Rev. Physiol., Biochem. Pharmacol.
 Revista Brasileira de Ciência do Solo;Rev. Bras. Cienc. Solo
 Revista Brasileira de Ensino de Quimica;Rev. Bras. Ensino Quim.
-Revista de Chimie (Bucharest, Romania);Rev. Chim. (Bucharest, Rom.)
-Revista de la Sociedad Quimica de Mexico;Rev. Soc. Quim. Mex.
-Revista de la Sociedad Quimica del Peru;Rev. Soc. Quim. Peru
+Revista Brasileira de Geofisica;Rev. Bras. Geofis.;;
+Revista Chilena de Historia Natural;Rev. Chil. Hist. Nat.;;
+Revista Geofisica;Rev. Geofis.;;
 Revista Mexicana de Ingenieria Quimica;Rev. Mex. Ing. Quim.
 Revista Portuguesa de Quimica;Rev. Port. Quim.
 Revista Romana de Materiale;Rev. Rom. Mater.
-Revue bryologique et lichénologique;Rev. bryol. lichénol.
-Revue de l'Electricite et de l'Electronique;Rev. Electr. Electron.
-Revue de Metallurgie / Cahiers d'Informations Techniques;Rev. Metall. / Cah. Inf. Tech.
-Revue de recherches du Service canadien des forêts;Rev. rech. Serv. can. for.
-Revue des Composites et des Materiaux Avances;Rev. Compos. Mater. Av.
-Revue des eaux et forêts;Rev. eaux for.
-Revue des Sciences de l'Eau;Rev. Sci. Eau
-Revue du bois et de ses applications;Rev. bois appl.
-Revue d’Archéometrie;Rev. Archéom.
-Revue forestière française;Rev. for. fr.
+Revista de Chimie (Bucharest, Romania);Rev. Chim. (Bucharest, Rom.)
+Revista de Saude Publica;Rev. Saude Publica;;
+Revista de la Sociedad Quimica de Mexico;Rev. Soc. Quim. Mex.
+Revista de la Sociedad Quimica del Peru;Rev. Soc. Quim. Peru
 Revue Francaise d'Oenologie;Rev. Fr. Oenol.
 Revue Generale de Thermique;Rev. Gen. Therm.
 Revue Generale des Caoutchoucs & Plastiques;Rev. Gen. Caoutch. Plast.
-Revue générale de Botanique;Rev. gen. Bot.
-Revue mensuelle des Musées et Collections de la ville Genève;Rev. mens. Mus. Collect. ville Genève
 Revue Roumaine de Biochimie;Rev. Roum. Biochim.
 Revue Roumaine de Chimie;Rev. Roum. Chim.
 Revue Roumaine de Physique;Rev. Roum. Phys.
+Revue bryologique et lichénologique;Rev. bryol. lichénol.
+Revue de Metallurgie / Cahiers d'Informations Techniques;Rev. Metall. / Cah. Inf. Tech.
+Revue de Micropaleontologie;Rev. Micropaleontol.;;
+Revue de Paleobiologie;Rev. Paleobiol.;;
+Revue de l'Electricite et de l'Electronique;Rev. Electr. Electron.
+Revue de recherches du Service canadien des forêts;Rev. rech. Serv. can. for.
+Revue des Composites et des Materiaux Avances;Rev. Compos. Mater. Av.
+Revue des Sciences de l'Eau;Rev. Sci. Eau
+Revue des eaux et forêts;Rev. eaux for.
+Revue du bois et de ses applications;Rev. bois appl.
+Revue d’Archéometrie;Rev. Archéom.
+Revue forestière française;Rev. for. fr.
+Revue générale de Botanique;Rev. gen. Bot.
+Revue mensuelle des Musées et Collections de la ville Genève;Rev. mens. Mus. Collect. ville Genève
 Revue suisse d'Hydrologie;Rev. suisse Hydrol.
-Revue suisse de viticulture arboriculture horticulture;Rev. suisse vitic. arboric. hortic.
 Revue suisse de Zoologie;Rev. suisse zool.
+Revue suisse de viticulture arboriculture horticulture;Rev. suisse vitic. arboric. hortic.
 Rheologica Acta;Rheol. Acta
 Rinsho Yakuri;Rinsho Yakuri
 Rivista dei Combustibili e dell'Industia Chimica;Riv. Combust. Ind. Chim.
-RNA;RNA
-RNA Biology;RNA Biol.
+RoFo Fortschritte auf dem Gebiete der Rontgenstrahlen und der Nuklearmedizin;RoFo Fortschr. Geb. Rontgenstr. Nuklearmed.;;
+Rocks and Minerals;Rocks Miner.;;
 Rocky Mountain Forest and Range Experiment Station, Forest Series;Rocky Mt. For. Range  Exp. Stn., For. Ser.
 Romanian Journal of Physics;Rom. J. Phys.
 Rossiiskii Khimicheskii Zhurnal;Ross. Khim. Zh.
@@ -3954,13 +4663,24 @@ Russian Journal of Plant Physiology;Russ. J. Plant Physiol.
 Russian Metallurgy;Russ. Metall.
 Russion Journal of Coordination Chemistry;Russ. J. Coord. Chem.
 SAH Bulletin;SAH Bull.
+SAMPE Journal;SAMPE J.
+SAR and QSAR in Environmental Research;SAR QSAR Environ. Res.
+SGU-Bulletin;SGU-Bull.
+SPE Drilling & Completion;SPE Drill. Complet;;
+SPE Formation Evaluation;SPE Form. Eval.;;
+SPE Journal;SPE J.;;
+SPE Production & Facilities;SPE Prod. Facil.
+SPE Production & Operations;SPE Prod. Oper.
+SPE Production Engineering;SPE Prod. Eng.;;
+SPE Reservoir Engineering;SPE Reservoir Eng;;
+SPE Reservoir Evaluation & Engineering;SPE Reservoir Eval. Eng.
+STAL, Sciences et Techniques de l'Animal de Laboratoire;STAL, Sci. Tech. Anim. Lab.
+Sage Open Engineering;Sage Open Eng.;;
 Saibo Kogaku;Saibo Kogaku
 Saishin Igaku;Saishin Igaku
 Salamandra;Salamandra
-SAMPE Journal;SAMPE J.
 Sankyo Kenkyusho Nenpo;Sankyo Kenkyusho Nenpo
 Sanop Misaengmul Hakhoechi;Sanop Misaengmul Hakhoechi
-SAR and QSAR in Environmental Research;SAR QSAR Environ. Res.
 Saussurea;Saussurea
 Sbornik Vedeckych Praci, Vysoka Skola Chemickotechnologicka Pardubice;Sb. Ved. Pr., Vys. Sk. Chemickotechnol. Pardubice
 Scandinavian Journal of Forest Research;Scand. J. For. Res.
@@ -3970,7 +4690,10 @@ Scandinavian Journal of Metallurgy;Scand. J. Metall.
 Scandinavian Journal of Statistics;Scand. J. Stat.
 School Science Review;Sch. Sci. Rev.
 Schriften aus der Forstlichen Fakultät der Universität Göttingen und der Niedersächsischen forstlichen Versuchsanstalt;Schr. Forstl. Fak. Univ. Gött. Niedersächs.  forstl. Vers.anst.
+Schriften der Koenigsberger Gelehrten Gesellschaft, Naturwissenschaftliche Klasse;Schr. Koenigsb. Gelehrten Ges., Naturwiss. Kl.;;
 Schriftenreihe Bayerisches Landesamt für Umweltschutz;Schr.reihe Bayer. Landesamt Umweltschutz
+Schriftenreihe Lebensraum Vorarlberg;Schr.reihe Lebensraum Vorarlberg
+Schriftenreihe Umwelt;Schr.reihe Umw.
 Schriftenreihe der Badischen Forstlichen Versuchsanstalt Freiburg;Schr.reihe Bad. Forstl. Vers.anst., Freibg.
 Schriftenreihe der Forstwissenschaftlichen Fakultät der Albert-Ludwigs-Universität Freiburg i. Br.;Schr.reihe Forstwiss. Fak. Albert-Ludwigs-Univ.  Freibg. i.B.
 Schriftenreihe der Landesanstalt für Ökologie, Landschaftsentwicklung und Forstplanung Nordrhein-Westfalen;Schr.reihe Landesanst. Ökol. Landsch.entwickl. Forstplan. Nordrh.-Westfal.
@@ -3981,8 +4704,6 @@ Schriftenreihe des Deutschen Rates für Landespflege;Schr.reihe Dtsch. Rat Lande
 Schriftenreihe des Institutes für Landespflege der Universität Freiburg;Schr.reihe Inst. Landespfl. Univ. Freibg.
 Schriftenreihe für Landschaftspflege und Naturschutz;Schr.reihe Landsch.pfl. Nat.schutz
 Schriftenreihe für Vegetationskunde;Schr.reihe Veg.kd.
-Schriftenreihe Lebensraum Vorarlberg;Schr.reihe Lebensraum Vorarlberg
-Schriftenreihe Umwelt;Schr.reihe Umw.
 Schweiss- und Prueftechnik;Schweiss Prueftech.
 Schweizer Archiv der Tierheilkunde;Schweiz. Arch. Tierheilkd.
 Schweizer Förster, Der;Schweiz. Förster
@@ -3997,16 +4718,20 @@ Schweizerische Apotheker-Zeitung;Schweiz. Apoth.-Ztg.
 Schweizerische Beiträge zur Dendrologie;Schweiz. Beitr. Dendrol.
 Schweizerische Gesellschaft für Phytomedizin, Info;Schweiz.  Ges. Phytomed., Info
 Schweizerische Interessengemeinschaft Industrieholz, Anleitung;Schweiz. Interessengem. Ind.holz, Anleit.
-Schweizerische landwirtschaftliche Forschung;Schweiz. landwirtsch. Forsch.
 Schweizerische Schreinerzeitung;Schweiz. Schreinerztg.
 Schweizerische Zeitschrift für Forstwesen;Schweiz. Z. Forstwes.
 Schweizerische Zeitschrift für Hydrologie;Schweiz. Z. Hydrol.
 Schweizerische Zeitschrift für Pilzkunde;Schweiz. Z. Pilzkd.
 Schweizerische Zeitschrift für Volkswirtschaft und Statistik;Schweiz. Z. Volkswirtsch. Stat.
-Science (Washington, DC, United States);Science (Washington, DC, U. S.)
+Schweizerische landwirtschaftliche Forschung;Schweiz. landwirtsch. Forsch.
 Science;Science
+Science (Washington, DC, United States);Science (Washington, DC, U. S.)
+Science China Materials;Sci. China Mater.;;
+Science Progress;Sci. Prog.
+Science Signaling;Sci. Signal.;;
 Science and Culture;Sci. Cult.
 Science and Technology of Advanced Materials;Sci. Technol. Adv. Mater.
+Science and Technology of Archaeological Research;Sci. Technol. Archaeolog. Res.;;
 Science and Technology of Welding and Joining /font>;Sci. Technol. Weld. Joining
 Science du Sol;Sci. Sol
 Science in China Series C: Life Sciences;Sci. China, Ser. C: Life Sci.
@@ -4017,11 +4742,16 @@ Science in China, Series A: Mathematics;Sci. China, Ser. A: Math.
 Science in China, Series B: Chemistry;Sci. China, Ser. B: Chem.
 Science in China, Series B: Chemistry, Life Sciences, & Earth Sciences;Sci. China, Ser. B: Chem.
 Science in China, Series E: Technological Sciences;Sci. China, Ser. E: Tech. Sci.
+Science of Advanced Materials;Sci. Adv. Mater.;;
+Science of Nature;Sci. Nat.;;
 Science of the Total Environment;Sci. Total Environ.
-Science Progress;Sci. Prog.
+ScienceOpen Research;ScienceOpen Res.;;
 Scientific American;Sci. Am.
+Scientific Data;Sci. Data;;
+Scientific Drilling;Sci. Drill.;;
 Scienze, Le;Scienze
 Scottish Forestry;Scott. For.
+Scottish Journal of Geology;Scott. J. Geol.;;
 Scripta Geobotanica;Scr. Geobot.
 Scripta Materialia;Scr. Mater.
 Scripta Metallurgica;Scr. Metall.
@@ -4030,19 +4760,20 @@ Seibutsu Kogaku Kaishi;Seibutsu Kogaku Kaishi
 Seitai no Kagaku;Seitai no Kagaku
 Semiconductor Science and Technology;Semicond. Sci. Technol.
 Semiconductors;Semiconductors
-Seminars in Cutaneous Medicine and Surgery;Semin. Cutaneous Med. Surg.
+Seminars in Cutaneous Medicine and Surgery;Semin. Cutan. Med. Surg.
 Sen'i Gakkaishi;Sen'i Gakkaishi
+Sensing and Bio-Sensing Research;Sens. Bio-Sens. Res.;;
+Sensor Letters;Sens. Lett.;;
 Sensors and Actuators, A: Physical;Sens. Actuators, A
 Sensors and Actuators, B: Chemical;Sens. Actuators, B
 Sensors and Actuators, B: Chemical Sensors and Materials;Sens. Actuators, B
+Separation Science and Technology;Sep. Sci. Technol.
 Separation and Purification Methods;Sep. Purif. Methods
 Separation and Purification Technology;Sep. Purif. Technol.
-Separation Science and Technology;Sep. Sci. Technol.
 Sepu;Sepu
 Seria Fizyka (Uniwersytet im. Adama Mickiewicza w Poznaniu);Ser. Fiz. (Uniw. im. Adama Mickiewicza Poznaniu)
 Serono Symposia Publications from Raven Press;Serono Symp. Publ. Raven Press
 Service de la recherche terres et forêts, Québec;Serv. rech. terres for., Qué.
-SGU-Bulletin;SGU-Bull.
 Shanghai Huanjing Kexue;Shanghai Huanjing Kexue
 Shengwu Huaxue Yu Shengwu Wuli Jinzhan;Shengwu Huaxue Yu Shengwu Wuli Jinzhan
 Shengwu Huaxue Yu Shengwu Wuli Xuebao;Shengwu Huaxue Yu Shengwu Wuli Xuebao
@@ -4059,7 +4790,10 @@ Silicates Industriels;Silic. Indus.
 Silicon Chemistry;Silicon Chem.
 Silva Fennica;Silva Fenn.
 Silvae Genetica;Silvae Genet.
+Sitzungsberichte der Akademie der Wissenschaften der DDR, Mathematik, Naturwissenschaften, Technik;Sitzungsber. Akad. Wiss. DDR, Math., Naturwiss., Tech.;;
+Sleep Science;Sleep Sci.;;
 Small;Small
+Small and Advanced Healthcare Materials;Small Adv. Healthcare Mater.;;
 Small-scale Forest Economics, Management and Policy;Small-scale For. Econ. Manage. Policy
 Smart Materials and Structures;Smart Mater. Struct.
 Soap, Cosmetics, Chemical Specialties;Soap, Cosmet., Chem. Spec.
@@ -4070,38 +4804,43 @@ Società Italiana di Ecologia, Atti;Soc. Ital. Ecol., Atti
 Sociologia Ruralis;Sociol. Ruralis
 Sociological Forum;Sociol. Forum
 Soft Matter;Soft Matter
+Soft Robotics;Soft Rob.;;
 Soil Biology & Biochemistry;Soil Biol. Biochem.
 Soil Biology and Biochemistry;Soil Biol. Biochem.
+Soil Discussions;Soil Discuss.;;
+Soil Research;Soil Res.;;
 Soil Science;Soil Sci.
-Soil Science and Plant Nutrition;Soil Sci. Plant Nutr.
 Soil Science Society of America Journal;Soil Sci. Soc. Am. J.
+Soil Science and Plant Nutrition;Soil Sci. Plant Nutr.
 Solar Energy Materials & Solar Cells;Sol. Energy Mater. Sol. Cells
 Solar Physics;Sol. Phys.
+Solid Earth;Solid Earth;;
+Solid Earth Discussions;Solid Earth Discuss.;;
 Solid State Communications;Solid State Commun.
-Solid State Electronics;Solid-State Electron.
+Solid-State Electronics;Solid-State Electron.
 Solid State Ionics;Solid State Ionics
 Solid State Nuclear Magnetic Resonance;Solid State Nucl. Magn. Reson.
 Solid State Sciences;Solid State Sci.
 Solid-State Electronics;Solid-State Electron.
 Solubility Data Series;Solubility Data Ser.
-Solvent Extraction and Ion Exchange;Solvent Extr. Ion Exch.
 Solvent Extraction Research and Development, Japan;Solvent Extr. Res. Dev., Jpn.
-Somatic Cell and Molecular Genetics;Somatic Cell Mol. Genet.
+Solvent Extraction and Ion Exchange;Solvent Extr. Ion Exch.
+Somatic Cell and Molecular Genetics;Somat. Cell Mol. Genet.
 Soobshcheniya Akademii Nauk Gruzii;Soobshch. Akad. Nauk Gruz. SSR
 South African Journal of Chemistry;S. Afr. J. Chem.
+South African Journal of Plant and Soil;S. Afr. J. Plant Soil;;
+South African Journal of Wildlife Research;S. Afr. J. Wildl. Res.;;
 Southeastern Geographer;Southeast. Geogr.
 Southeastern Geology;Southeast. Geol.
+Southern African Institute of Mining and Metallurgy;SAIMM;;
+Southern Journal of Applied Forestry;South. J. Appl. For.;;
 Southwestern Naturalist;Southwest. Nat.
 Soviet Journal of Quantum Electronics;Sov. J. Quantum Electron.
-sozialistische Forstwirtschaft, Die;Sozial. Forstwirtsch.
-SPE Production & Facilities;SPE Prod. Facil.
-SPE Production & Operations;SPE Prod. Oper.
-SPE Reservoir Evaluation & Engineering;SPE Reservoir Eval. Eng.
 Special Publication - Royal Society of Chemistry;Spec. Publ. - R. Soc. Chem.
 Spectra Analyse;Spectra Anal.
 Spectra Biologie;Spectra Biol.
-Spectrochimica Acta, Part A: Molecular and Biomolecular Spectroscopy;Spectrochim. Acta, Part A
 Spectrochimica Acta, Part A: Molecular Spectroscopy;Spectrochim. Acta, Part A
+Spectrochimica Acta, Part A: Molecular and Biomolecular Spectroscopy;Spectrochim. Acta, Part A
 Spectrochimica Acta, Part B: Atomic Spectroscopy;Spectrochim. Acta, Part B
 Spectroscopic Properties of Inorganic and Organometallic Compounds;Spectrosc. Prop. Inorg. Organomet. Compd.
 Spectroscopy (Amsterdam, Netherlands);Spectroscopy (Amsterdam, Neth.)
@@ -4119,13 +4858,15 @@ Springer Series in Surface Sciences;Springer Ser. Surf. Sci.
 Stahl und Eisen;Stahl Eisen
 Stain Technology;Stain Technol.
 Stal';Stal'
-STAL, Sciences et Techniques de l'Animal de Laboratoire;STAL, Sci. Tech. Anim. Lab.
 Stapfia;Stapfia
 Starch/Staerke;Starch/Staerke
 Statistisches Jahrbuch der Schweiz;Stat. Jahrb. Schweiz
 Staub - Reinhaltung der Luft;Staub - Reinhalt. Luft
 Steel Research International;Steel Res. Int.
 Steklo i Keramika;Steklo Keram.
+Stem Cell Reports;Stem Cell Rep.;;
+Stem Cell Research & Therapy;Stem Cell Res. Ther.;;
+Stephan Mueller Special Publication Series;Stephan Mueller Spec. Publ. Ser.;;
 Steroids;Steroids
 Stiftung Reusstal, Jahresbericht;Stift. Reusstal, Jahresber.
 Struct.--Process., Meas., Phenom. Journal of Vacuum Science & Technology, B: Microelectronics and Nanometer Structures--Processing, Measurement, and Phenomena;J. Vac. Sci. Technol., B: Microelectron. Nanometer
@@ -4133,8 +4874,9 @@ Structural Chemistry;Struct. Chem.
 Structure (Cambridge, MA, United States);Structure (Cambridge, MA, U. S.)
 Structure and Bonding;Struct. Bond.
 Studia Biophysica;Stud. Biophys.
-Studia forestalia suecica;Stud. for. suec.
+Studia Quaternaria;Stud. Quat.;;
 Studia Universitatis Babes-Bolyai, Chemia;Stud. Univ. Babes-Bolyai, Chem.
+Studia forestalia suecica;Stud. for. suec.
 Studies in Conservation;Stud. Conserv.
 Studies in Environmental Science;Stud. Environ. Sci.
 Studies in Natural Products Chemistry;Stud. Nat. Prod. Chem.
@@ -4152,18 +4894,25 @@ Supramolecular Chemistry;Supramol. Chem.
 Supramolecular Photosensitive and Electroactive Materials;Supramol. Photosensit. Electroact. Mater.
 Supramolecular Science;Supramol. Sci.
 Surface & Coatings Technology;Surf. Coat. Technol.
-Surface and Coatings Technology;Surf. Coat. Technol.
-Surface and Colloid Science;Surf. Colloid Sci.
-Surface and Interface Analysis;Surf. Interface Anal.
 Surface Coatings International;Surf. Coat. Int.
 Surface Engineering;Surf. Eng.
 Surface Review and Letters;Surf. Rev. Lett.
 Surface Science;Surf. Sci.
 Surface Science Reports;Surf. Sci. Rep.
 Surface Science Spectra;Surf. Sci. Spectra
+Surface and Coatings Technology;Surf. Coat. Technol.
+Surface and Colloid Science;Surf. Colloid Sci.
+Surface and Interface Analysis;Surf. Interface Anal.
+Sustainability Water Quality and Ecology;Sustainability Water Qual. Ecol.;;
+Sustainability of Water Quality and Ecology;Sustainability Water Qual. Ecol.;;
+Sustainable Energy Technologies and Assessments;Sustainable Energy Technol. Assess.;;
+Sustainable Energy, Grids and Networks;Sustainable Energy Grids Networks;;
+Sustainable Materials and Technologies;Sustainable Mater.Technol.;;
 Svarochnoe Proizvodstvo;Svar. Proizvod.
 Svensk Botanisk Tidskrift;Sven. Bot. Tidskr.
 Sverkhprovodimost: Fizika, Khimiya, Tekhnika;Sverkhprovodimost: Fiz., Khim., Tekh.
+Swarm Intelligence;Swarm Intell.;;
+Swarm and Evolutionary Computation;Swarm Evol. Comput.;;
 Sydowia;Sydowia
 Symbiosis;Symbiosis
 Symbolae Botanicae Upsalienses;Symb. Bot. Ups.
@@ -4180,6 +4929,8 @@ Synthetic Metals;Synth. Met.
 Systematic Biology;Syst. Biol.
 Systematic Entomology;Syst. Entomol.
 Säugetierkundliche Mitteilungen;Säugetierkd. Mitt.
+THEOCHEM;THEOCHEM
+THEOCHEM Journal of Molecular Structure;THEOCHEM
 Taehan Kumsok Hakhoechi;Taehan Kumsok Hakhoechi
 Taehan Kumsok, Chaeryo Hakhoechi;Taehan Kumsok, Chaeryo Hakhoechi
 Tages-Anzeiger Magazin;Tages-Anz. Mag.
@@ -4193,8 +4944,8 @@ Technical Physics Letters;Tech. Phys. Lett.
 Technical Report Forest Engineering Research Institute of Canada;Tech. Rep. For. Eng. Res. Inst. Can.
 Technical Reports in Hydrology and Water Resources;Tech. Rep. Hydrol. Water Resour.
 Techniques de l'Ingenieur, Constantes Physico-Chimiques;Tech. Ing. Constantes Phys. Chim.
-Techniques de l'Ingenieur, Genie des Procede;Tech. Ing. Genie Procedes
 Techniques de l'Ingenieur, Genie Nuclear;Tech. Ing. Genie Nucl.
+Techniques de l'Ingenieur, Genie des Procede;Tech. Ing. Genie Procedes
 Techniques de l'Ingenieur, Materiaux Fonctionnels;Tech. Ing. Mater. Fond.
 Techniques de l'Ingenieur, Materiaux Metalliques;Tech. Ing. Mater. Met.
 Techniques de l'Ingenieur, Plastiques et Composites;Tech. Ing. Plast. Compos.
@@ -4203,8 +4954,10 @@ Techniques de l'Ingenieur, Sciences Fondamentales: Physique, Chemie;Tech. Ing. S
 Technische Rundschau;Tech. Rundsch.
 Technische Uberwachung;Tech. Uberwach.
 Technisches Messen;Tech. Mess.
+Technological Forecasting and Social Change;Technol. Forecasting Social Change;;
 Technology Reports of the Osaka University;Technol. Rep. Osaka Univ.
 Technology Review;Technol. Rev.
+Technology in Cancer Research & Treatment;Technol. Cancer Res. Treat.;;
 Telma;Telma
 Tenside, Surfactants, Detergents;Tenside, Surfactants, Deterg.
 Teoreticheskaya i Eksperimental'naya Khimiya;Teor. Eksp. Khim.
@@ -4212,7 +4965,7 @@ Teoreticheskaya i Matematicheskaya Fizika;Teor. Mat. Fiz.
 Teoreticheskie Osnovy Khimicheskoi Tekhnologii;Teor. Osn. Khim. Tekhnol.
 Teploenergetika (Moscow);Teploenergetika (Moscow)
 Teplofizika Vysokikh Temperatur;Teplofiz. Vys. Temp.
-Teratology;Birth Defects Res., Part A
+Teratology;Teratology
 Terre et la Vie, La;Terre Vie
 Tetrahedron;Tetrahedron
 Tetrahedron Letters;Tetrahedron Lett.
@@ -4220,22 +4973,22 @@ Tetrahedron: Asymmetry;Tetrahedron: Asymmetry
 Tetsu to Hagane;Tetsu to Hagane
 Textile Research Journal;Text. Res. J.
 The American Naturalist;Am. Nat.
+The Journal of Physical Chemistry A;J. Phys. Chem. A;;
 The Plant Cell;Plant Cell
-THEOCHEM;THEOCHEM
-THEOCHEM Journal of Molecular Structure;THEOCHEM
 Theoretica Chimica Acta;Theor. Chim. Acta
-Theoretical and Applied Climatology;Theor. Appl. Climatol.
-Theoretical and Applied Genetics;Theor. Appl. Genet.
-Theoretical and Applied Genetics;Theor. Appl. Genet.
-Theoretical and Experimental Chemistry;Theor. Exp. Chem.
 Theoretical Chemistry Accounts;Theor. Chem. Acc.
+Theoretical Ecology;Theor. Ecol.;;
 Theoretical Foundations of Chemical Engineering;Theor. Found. Chem. Eng.
 Theoretical Population Biology;Theor. Popul. Biol.
+Theoretical and Applied Climatology;Theor. Appl. Climatol.
+Theoretical and Applied Genetics;Theor. Appl. Genet.
+Theoretical and Applied Mechanics Letters;Theor. Appl. Mech. Lett.;;
+Theoretical and Experimental Chemistry;Theor. Exp. Chem.
 Theriogenology;Theriogenology
 Thermochimica Acta;Thermochim. Acta
 Thin Solid Films;Thin Solid Films
-Thrombosis and Haemostasis;Thromb. Haemostasis
 Thrombosis Research;Thromb. Res.
+Thrombosis and Haemostasis;Thromb. Haemost.
 Thurgauer Jahrbuch;Thurg. Jahrb.
 Tianran Chanwu Yanjiu Yu Kaifa;Tianran Chanwu Yanjiu Yu Kaifa
 Timber Bulletin for Europe;Timber Bull. Eur.
@@ -4249,13 +5002,16 @@ Topics in Current Chemistry;Top. Curr. Chem.
 Topics in Fluorescence Spectroscopy;Top. Fluoresc. Spectrosc.
 Topics in Inorganic Chemistry;Top. Inorg. Chem.
 Topics in Stereochemistry;Top. Stereochem.
-Toxicological and Environmental Chemistry;Toxicol. Environ. Chem.
 Toxicological Sciences;Toxicol. Sci.
+Toxicological and Environmental Chemistry;Toxicol. Environ. Chem.
+Toxicologie Analytique et Clinique;Toxicol. Anal. Clin.;;
 Toxicology;Toxicology
-Toxicology and Applied Pharmacology;Toxicol. Appl. Pharmacol.
-Toxicology in Vitro;Toxicol. in Vitro
 Toxicology Letters;Toxicol. Lett.
 Toxicology Mechanisms and Methods;Toxicol. Mech. Methods
+Toxicology Reports;Toxicol. Rep.;;
+Toxicology Research;Toxicol. Res.;;
+Toxicology and Applied Pharmacology;Toxicol. Appl. Pharmacol.
+Toxicology in Vitro;Toxicol. in Vitro
 Toxicon;Toxicon
 TrAC, Trends in Analytical Chemistry;TrAC, Trends Anal. Chem.
 Trace Elements and Electrolytes;Trace Elem. Electrolytes
@@ -4268,21 +5024,35 @@ Transactions of the Institute of Metal Finishing;Trans. Inst. Met. Finish.
 Transactions of the Institution of Mining and Metallurgy Section A;Trans. Inst. Min. Metall., Sect. A
 Transactions of the Institution of Mining and Metallurgy Section B;Trans. Inst. Min. Metall., Sect. B
 Transactions of the Institution of Mining and Metallurgy Section C;Trans. Inst. Min. Metall., Sect. C
+Transactions of the Korean Institute of Electrical Engineers;Trans. Korean Inst. Electr. Eng.;;
+Transactions of the Korean Society of Mechanical Engineers, A;Trans. Korean Soc. Mech. Eng. A;;
+Transactions of the Korean Society of Mechanical Engineers, B;Trans. Korean Soc. Mech. Eng. B;;
 Transactions of the Optical Society;Trans. Opt. Soc.
 Transactions of the Royal Society of Edinburgh, Earth Sciences;Trans. R. Soc. Edinb., Earth Sci.
 Transactions of the SAEST;Trans. SAEST
+Transactions of the South African Institute of Electrical Engineering;Trans. South Afr. Inst. Electr. Eng.;;
+Transactions on Electrical and Electronic Materials;Trans. Electr. Electron. Mater.;;
 Transgenic Research;Transgenic Res.
 Transition Metal Chemistry (Dordrecht, Netherlands);Transition Met. Chem. (Dordrecht, Neth.)
 Transition Metal Chemistry (London);Transition Met. Chem. (London)
+Translational Materials Research;Transl. Mater. Res.;;
+Translational Oncology;Trans. Oncol.;;
+Translational Proteomics;Transl. Proteomics;;
+Translational Psychiatry;Transl. Psychiatry;;
 Transplantation Proceedings;Transplant. Proc.
+Transportation Geotechnics;Transp. Geotech.;;
+Transportation Research Procedia;Transp. Res. Procedia;;
 Travaux Scientifiques du Parc National de la Vanoise;Trav. Sci. Parc Natl. Vanoise
 Travaux Station de recherches des eaux et forêts;Trav. Stn. rech. eaux for.
+Tree Genetics & Genomes;Tree Genet. Genomes;;
 Tree Physiology;Tree Physiol.
-Tree-ring Bulletin;Tree-ring Bull.
 Tree-Ring Research;Tree-Ring Res.
+Tree-ring Bulletin;Tree-ring Bull.
 Trees;Trees
 Trends in Analytical Chemistry;Trends Anal. Chem.
 Trends in Biochemical Sciences;Trends Biochem. Sci.
+Trends in Biomaterials and Artificial Organs;Trends Biomater. Artif. Organs;;
+Trends in Biosciences;Trends Biosci.;;
 Trends in Biotechnology;Trends Biotechnol.
 Trends in Ecology and Evolution;Trends Ecol. Evol.
 Trends in Endocrinology and Metabolism;Trends Endocrinol. Metab.
@@ -4299,10 +5069,15 @@ Tribology Transactions;Tribol. Trans.
 Trochilus;Trochilus
 Tropical Agriculture;Trop. Agric.
 Tropical Bryology;Trop. Bryol.
+Tropical Ecology;Trop. Ecol.;;
+Tropical Life Sciences Research;Trop. Life Sci. Res.;;
 Tsitologiya;Tsitologiya
 Tsvetnye Metally (Moscow);Tsvetn. Met. (Moscow)
 Tuexenia;Tuexenia
+Turkish Journal of Botany;Turk. J. Bot.;;
 Turkish Journal of Chemistry;Turk. J. Chem.
+Turkish Journal of Earth Sciences;Turk. J. Earth Sci.;;
+Turkish Journal of Zoology;Turk. J. Zool.;;
 Tätigkeitsbericht der Naturforschenden Gesellschaft Baselland;Tätigk.ber. Nat.forsch. Ges. Baselland
 Tübinger Geographische Studien;Tüb. Geogr. Stud.
 U.S. Geological Survey Professional Paper;U.S. Geol. Surv. Prof. Pap.
@@ -4327,15 +5102,22 @@ United States Department of Agriculture Miscellaneous Publication;U.S. Dep. Agri
 University of Arizona Bulletin;Univ. Ariz. Bull.
 Unser Wald;Unser Wald
 Untertoggenburger Neujahrsblätter;Untertoggenburg. Neujahrsbl.
+Urban Climate;Urban Clim.;;
+Urban Forestry & Urban Greening;Urban For. Urban Greening;;
+Urban Water Journal;Urban Water J.;;
 Uspekhi Khimii;Usp. Khim.
 Uzbekskii Khimicheskii Zhurnal;Uzb. Khim. Zh.
+VDI Berichte;VDI Ber.
+VGB Kraftwerkstechnik;VGB Kraftwerkstech.
+VTT Symposium;VTT Symp.
 Vacuum;Vacuum
 Vakuum in Forschung und Praxis;Vak. Forsch. Prax.
 Vascular Pharmacology;Vasc. Pharmacol.
-VDI Berichte;VDI Ber.
 Vecteur Environnement;Vecteur Environ.
+Vegetable Crops Research Bulletin;Veg. Crops. Res. Bull.;;
 Vegetatio;Vegetatio
 Vegetation History and Archaeobotany;Veg. Hist. Archaeobot.
+Vehicular Communications;Veh. Commun.;;
 Verhandlungen - Internationale Vereinigung für Theoretische und Angewandte Limnologie;Verh. - Int. Ver. Theor. Angew. Limnol.
 Verhandlungen der Deutschen Physikalischen Gesellschaft;Verh. Dtsch. Phys. Ges.
 Verhandlungen der Deutschen Zoologischen Gesellschaft;Verh. Dtsch. Zool. Ges.
@@ -4345,9 +5127,10 @@ Verhandlungen der Naturforschenden Gesellschaft in Basel;Verh. Nat.forsch. Ges. 
 Verhandlungen der Schweizerischen naturforschenden Gesellschaft;Verh. Schweiz. nat.forsch. Ges.
 Vermessung, Photogrammetrie, Kulturtechnik;Vermess. Photogramm. Kult.tech.
 Versuchsanstalt für Wasserbau, Hydrologie und Glaziologie;Vers.anst. Wasserbau Hydrol. Glaziol.
+Vertebrate Anatomy Morphology Palaeontology;Vertebr. Anat. Morphol. Paleontol.;;
+Veröffentlichungen Natur-Museum Luzern;Veröff. Nat.-Mus. Luzern
 Veröffentlichungen der Landesstelle für Naturschutz und Landschaftspflege in Baden-Württemberg;Veröff. Landesstelle Nat.schutz Landsch.pfl. Baden-Württ.
 Veröffentlichungen des Geobotanischen Institutes der Eidg. Technischen Hochschule, Stiftung Rübel in Zürich;Veröff. Geobot. Inst. Eidgenöss. Tech. Hochsch., Stift. Rübel  Zür.
-Veröffentlichungen Natur-Museum Luzern;Veröff. Nat.-Mus. Luzern
 Vestnik Moskovskogo Universiteta, Seriya 2: Khimiya;Vestn. Mosk. Univ., Ser. 2: Khim.
 Vestnik Moskovskogo Universiteta, Seriya 3: Fizika, Astronomiya;Vestn. Mosk. Univ., Ser. 3: Fiz., Astron.
 Vestnik Sankt-Peterburgskogo Universiteta, Seriya 4: Fizika, Khimiya;Vestn. S.-Peterb. Univ., Ser. 4: Fiz., Khim.
@@ -4356,11 +5139,13 @@ Vestsi Akademii Navuk Belarusi, Seryya Biyalagichnykh Navuk;Vestsi Akad. Navuk B
 Vestsi Akademii Navuk Belarusi, Seryya Fizika-Energetychnykh Navuk;Vestsi Akad. Navuk BSSR, Ser. Fiz.-Energ. Navuk
 Vestsi Akademii Navuk Belarusi, Seryya Khimichnykh Navuk;Vestsi Akad. Navuk BSSR, Ser. Khim. Navuk
 Vestsi Natsyyanal'nai Akademii Navuk Belarusi, Seryya Khimichnykh Navuk;Vestsi Nats. Akad. Navuk Belarusi, Ser. Khim. Navuk
-VGB Kraftwerkstechnik;VGB Kraftwerkstech.
 Vibrational Spectroscopy;Vib. Spectrosc.
 Vierteljahrsschrift der Naturforschenden Gesellschaft in Zürich;Vierteljahrsschr. Nat.forsch. Ges. Zür.
 Viral Immunology;Viral Immunol.
 Virology;Virology
+Virology Reports;Virol. Rep.;;
+Virtual Journal of Atomic Quantum Fluids;Virtual J. At. Quantum Fluids;;
+Virus Evolution;Virus Evol.;;
 Virus Genes;Virus Genes
 Virus Research;Virus Res.
 Vitamins and Hormones (New York);Vitam. Horm. (N.Y.)
@@ -4368,39 +5153,61 @@ Vitis;Vitis
 Vogelwarte, Die;Vogelwarte
 Vogelwelt, Die;Vogelwelt
 Voprosy Meditsinskoi Khimii;Vopr. Med. Khim.
-VTT Symposium;VTT Symp.
 Vysokochistye Veshchestva;Vysokochist. Veshchestva
 Vysokomolekulyarnye Soedineniya, Seriya A;Vysokomol. Soedin., Ser. A
 Vysokomolekulyarnye Soedineniya, Seriya A i Seriya B;Vysokomol. Soedin., Ser. A Ser. B
 Vysokomolekulyarnye Soedineniya, Seriya B: Kratkie Soobshcheniya;Vysokomol. Soedin., Ser. B
 Vögel der Heimat;Vögel Heim.
+WIREs Climate Change;WIREs Clim. Change;;
+WIREs Cognitive Science;WIREs Cognit. Sci.;;
+WIREs Computational Molecular Science;WIREs Comput. Mol. Sci.;;
+WIREs Computational Statistics;WIREs Comput. Stat.;;
+WIREs Data Mining and Knowledge Discovery;WIREs Data Min. Knowl. Discovery;;
+WIREs Developmental Biology;WIREs Dev. Biol.;;
+WIREs Energy and Environment;WIREs Energy Environ.;;
+WIREs Membrane Transport and Signaling;WIREs Membr. Transport Signaling;;
+WIREs Nanomedicine and Nanobiotechnology;WIREs Nanomed. Nanobiotechnol.;;
+WIREs RNA;WIREs RNA;;
+WIREs Systems Biology and Medicine;WIREs Syst. Biol. Med.;;
+WIREs Water;WIREs Water;;
+WIT Transactions on the Built Environment;WIT Trans. Built Environ.;;
 Wald und Holz;Wald Holz
 Wald, Der;Wald
 Wald- und Holzwirtschaft, Die;Wald- Holzwirtsch.
 Waldarbeit, Die;Waldarbeit
 Wasser und Boden;Wasser Boden
-wasser, energie, luft;Wasser energ. luft
 Wasser- und Energiewirtschaft;Wasser- Energ.wirtsch.
 Wasserwirtschaft Wassertechnik;Wasserwirtsch. Wassertech.
 Waste Management (Oxford);Waste Manage. (Oxford)
 Waste Management (Tucson, Arizona);Waste Manage. (Tucson, Ariz.)
 Waste Management and Research;Waste Manage. Res.
+Water Alternatives;Water Altern.;;
 Water Environment Research;Water Environ. Res.
 Water Quality Research Journal of Canada;Water Qual. Res. J. Can.
+Water Quality, Exposure and Health;Water Qual. Exposure Health;;
 Water Research;Water Res.
 Water Resources;Water Resour.
 Water Resources Bulletin;Water Resour. Bull.
 Water Resources Research;Water Resour. Res.
-Water Resources Research;Water Resour. Res.
+Water Resources and Economics;Water Resour. Econ.;;
+Water Resources and Industry;Water Resour. Ind.;;
+Water Resources and Rural Development;Water Resour. Rural Dev.;;
+Water Science;Water Sci.;;
 Water Science and Technology;Water Sci. Technol.
 Water Services;Water Serv.
+Water Sewage and Effluent;Water Sewage Effluent;;
+Water and Energy International;Water Energy Int.;;
 Water, Air and Soil Pollution;Water Air Soil Pollut.
 Water, Air, & Soil Pollution;Water, Air, Soil Pollut.
 Wear;Wear
+Weather and Climate Extremes;Weather Clim. Extremes;;
+Weather, Climate, and Society;Weather Clim. Soc.;;
+Web Ecology;Web Ecol.;;
 Weed Science;Weed Sci.
 Weed Technology;Weed Technol.
 Werkstoffe und Korrosion;Werkst. Korros.
 Western Journal of Applied Forestry;West. J. Appl. For.
+Wetland Science;Wetland Sci.;;
 Wetter und Leben;Wetter Leben
 What’s New in Forest Research;What’s New For. Res.
 Wildbach- und Lawinenverbau;Wildbach- Lawinenverbau
@@ -4408,16 +5215,21 @@ Wildfire;Wildfire
 Wildlife Biology;Wildl. Biol.
 Wildlife Monographs;Wildl. Monogr.
 Wildlife Society Bulletin;Wildl. Soc. Bull.
+Wiley Interdisciplinary Reviews;WIRES;;
+Wiley Interdisciplinary Reviews: Cognitive Science;Wiley Interdiscip. Rev. Cognit. Sci.;;
+Wiley Interdisciplinary Reviews: Computational Molecular Science;WIREs Comput Mol Sci;;
 Wilson Bulletin;Wilson Bull.
+Wind Engineering;Wind Eng.;;
 Windahlia;Windahlia
 Winterberichte des Eidg. Institutes für Schnee- und Lawinenforschung;Winterber. Eidgenöss. Inst. Schnee- Lawinenforsch.
 Wireless Communications;Wireless Commun.
 Wissenschaftliche Alpenvereinshefte;Wiss. Alp.ver.heft
 Wissenschaftliche Zeitschrift der Technischen Universität Dresden, Separatreihe 5;Wiss. Z. Tech. Univ. Dresd., Sep.r. 5
 Wochenblatt für Papierfabrikation;Wochenbl. Papierfabr.
-Wood and Fiber Science;Wood Fiber Sci.
 Wood Research;Wood Res.
 Wood Science and Technology;Wood Sci. Technol.
+Wood and Fiber Science;Wood Fiber Sci.
+World Allergy Organization Journal;World Allergy Organ. J.;;
 World Archaeology;World Archeol.
 World Journal of Microbiology and Biotechnology;World J. Microbiol. Biotechnol.
 World Resource Review;World Resour. Rev.
@@ -4428,7 +5240,6 @@ Wuli Huaxue Xuebao;Wuli Huaxue Xuebao
 Wuli Xuebao;Wuli Xuebao
 X-Ray Spectrometry;X-Ray Spectrom.
 X-Ray Structure Analysis Online;X-Ray Struct. Anal. Online
-Xenobiotica;Xenobiotica
 Xenobiotica;Xenobiotica
 Yadernaya Fizika;Yad. Fiz.
 Yakhak Hoechi;Yakhak Hoechi
@@ -4450,6 +5261,15 @@ Zashchita Metallov;Zashch. Met.
 Zavodskaya Laboratoriya;Zavod. Lab.
 Zeiss – Informationen;Zeiss – Inf.
 Zeitschrift der Arbeitsgemeinschaft österreichischer Entomologen;Z. Arb.gem. österr. Entomol.
+Zeitschrift der Ostpreussischen Meschkinnes Forschung;Z. Ostpreuss. Meschkinnes Forsch.;;
+Zeitschrift fuer Kristallographie;Z. Kristallogr.;;
+Zeitschrift fuer Metallkunde;Z. Metallkd.;;
+Zeitschrift fuer Naturforschung, B: Chemical Sciences;Z. Naturforsch., B: Chem. Sci.;;
+Zeitschrift fur Bienenforschung;Z. Bienenforsch.;;
+Zeitschrift fur Flugwissenschaften und Weltraumforschung;Z. Flugwiss. Weltraumforsch.;;
+Zeitschrift fur Kristallographie;Z. Kristallogr.;;
+Zeitschrift fur Kristallographie - New Crystral Stuctures;Z. Kristallogr. - New Cryst. Struct.;;
+Zeitschrift fur Rechtsmedizin;Z. Rechtsmed.;;
 Zeitschrift für Agrargeschichte und Agrarsoziologie;Z. Agrargesch. Agrarsoziol.
 Zeitschrift für Analytische Chemie;Z. Anal. Chem.
 Zeitschrift für Angewandte Entomologie;Z. Angew. Entomol.
@@ -4457,15 +5277,13 @@ Zeitschrift für Angewandte Mathematik und Physik;ZAMP
 Zeitschrift für Angewandte Physik und Chemie;Z. Elektrochem. Angew. Phys. Chem.
 Zeitschrift für Anorganische Chemie;Z. Anorg. Chem.
 Zeitschrift für Anorganische und Allgemeine Chemie;Z. Anorg. Allg. Chem.
-Zeitschrift für Anorganische und Allgemeine Chemie;Z. Anorg. Allg. Chem.
-Zeitschrift für das Forst- und Jagdwesen;Z. Forst- Jagdwes.
 Zeitschrift für Forstgenetik und Forstpflanzenzüchtung;Z. Forstgenet. Forstpflanzenzücht.
 Zeitschrift für Geologische Wissenschaften;Z. Geol. Wiss.
 Zeitschrift für Geomorphologie;Z. Geomorphol.
 Zeitschrift für Gletscherkunde und Glazialgeologie;Z. Gletsch.kd. Glazialgeol.
 Zeitschrift für Jagdwissenschaft;Z. Jagdwiss.
-Zeitschrift für Kristallographie - New Crystal Structures;Z. Kristallogr. - New Cryst. Struct.
 Zeitschrift für Kristallographie;Z. Kristallogr.
+Zeitschrift für Kristallographie - New Crystal Structures;Z. Kristallogr. - New Cryst. Struct.
 Zeitschrift für Kristallographie, Kristallgeometrie, Kristallphysik, Kristallchemie;Z. Kristallogr. Kristallgeom. Kristallphys. Kristallchem.
 Zeitschrift für Kulturtechnik und Flurbereinigung;Z. Kult.tech. Flurbereinig.
 Zeitschrift für Lebensmittel-Untersuchung und -Forschung;Z. Lebensm.-Unters. Forsch.
@@ -4494,9 +5312,11 @@ Zeitschrift für Säugetierkunde;Z. Säugetierkd.
 Zeitschrift für Tierpsychologie;Z. Tierpsychol.
 Zeitschrift für Wasser- und Abwasserforschung;Z. Wasser Wasser-Forsch.
 Zeitschrift für Weltforstwirtschaft;Z. Weltforstwirtsch.
-Zeitschrift für wissenschaftliche Zoologie;Z. wiss. Zool.
 Zeitschrift für Zellforschung;Z. Zellforsch.
+Zeitschrift für das Forst- und Jagdwesen;Z. Forst- Jagdwes.
+Zeitschrift für wissenschaftliche Zoologie;Z. wiss. Zool.
 Zeitschrift für Ökologie und Naturschutz;Z. Ökol. Nat.schutz
+Zentralblatt fur Pharmazie, Pharmakotherapie und Laboratoriumsdiagnostik;Zentralbl. Pharm. Pharmakother. Laboratoriumsdiagn.;;
 Zentralblatt für Bakteriologie, Supplement;Zentralbl. Bakteriol., Suppl.
 Zeolites;Zeolites
 Zhipu Xuebao;Zhipu Xuebao
@@ -4514,25 +5334,41 @@ Zhurnal Evolyutsionnoi Biokhimii i Fiziologii;Zh. Evol. Biokhim. Fiziol.
 Zhurnal Fizicheskoi Khimii;Zh. Fiz. Khim.
 Zhurnal Nauchnoi i Prikladnoi Fotografii;Zh. Nauchn. Prikl. Fotogr.
 Zhurnal Neorganicheskoi Khimii;Zh. Neorg. Khim.
-Zhurnal Obshchei Biologii;Zh. Obshch. Khim.
+Zhurnal Obshchei Biologii;Zh. Obshch. Biol.
 Zhurnal Obshchei Khimii;Zh. Obshch. Khim.
 Zhurnal Organicheskoi Khimii;Zh. Org. Khim.
 Zhurnal Organichnoi ta Farmatsevtichnoi Khimii;Zh. Org. Farm. Khim.
-Zhurnal Prikladnoi Khimii (S. -Peterburg);Zh. Prikl. Khim. (Leningrad)
 Zhurnal Prikladnoi Khimii;Zh. Prikl. Khim.
+Zhurnal Prikladnoi Khimii (S. -Peterburg);Zh. Prikl. Khim. (Leningrad)
 Zhurnal Prikladnoi Spektroskopii;Zh. Prikl. Spektrosk.
 Zhurnal Strukturnoi Khimii;Zh. Strukt. Khim.
 Zhurnal Tekhnicheskoi Fiziki;Zh. Tekh. Fiz.
 Zhurnal Vsesoyuznogo Khimicheskogo Obshchestva im. D. I. Mendeleeva;Zh. Vses. Khim. O-va. im. D. I. Mendeleeva
+Zoological Journal of the Linnean Society;Zool. J. Linn. Soc.;;
+Zoological Letters;Zool. Lett.;;
 Zoologischer Anzeiger;Zool. Anz.
 Zoologischer Garten N.F.;Zool. Gart. N.F.
 Zoologisches Jahrbuch, Abteilung für Systematik;Zool. Jahrb. Abt. Syst.
 Zoomorphology;Zoomorphology
+Zoosystematics and Evolution;Zoosyst. Evol.;;
 Zuger Nachrichten;Zuger Nachr.
 Zuger Neujahrsblatt;Zuger Neujahrsbl.
 Züchter, Der;Züchter
 Zürcher Geographische Schriften;Zür. Geogr. Schr.
 Zürcher Wald;Zür.ld
+eXPRESS Polymer Letters;eXPRESS Polym. Lett.;;
+forstlige forsøgsvaesen i Danmark, Det;Forstl. forsøgsvaes. Dan.
+forêt, La;Forêt
+nostro paese, Il;Nostro paese
+npj Biofilms and Microbiomes;npj Biofilms Microbiomes;;
+npj Computational Materials;npj Comput. Mater.;;
+npj Genomic Medicine;npj Genomic Med.;;
+npj Quantum Information;npj Quantum Inf.;;
+npj Systems Biology and Applications;npj Syst. Biol. Appl.;;
+ornithologische Beobachter, Der;Ornithol. Beob.
+praktische Forstwirt für die Schweiz, Der;Prakt. Forstwirt Schweiz
+sozialistische Forstwirtschaft, Die;Sozial. Forstwirtsch.
+wasser, energie, luft;Wasser energ. luft
 Ökologie und Landbau;Ökol. Landbau
-Österreichische botanische Zeitschrift;Österr. bot. Z.
 Österreichische Forstzeitung;Österr. Forstztg.
+Österreichische botanische Zeitschrift;Österr. bot. Z.

--- a/journals/journal_abbreviations_general.csv
+++ b/journals/journal_abbreviations_general.csv
@@ -59,7 +59,7 @@ Achievements in the Life Sciences;Achiev. Life Sci.;;
 Acoustical Science and Technology;Acoust. Sci. Technol.;;
 Acta Agralia Fennica;Acta Agral. Fenn.
 Acta Agraria et Silvestria, Seria Lesna, Krakau;Acta Agrar. Silv., Ser. Lesn. (Krak.)
-Acta Anatomica;Acta Anat.
+Acta Anatomica;Acta Anat. (Basel)
 Acta Archaeologica;Acta Archaeol.
 Acta Bernensia;Acta Bern.
 Acta Biochimica Polonica;Acta Biochim. Pol.
@@ -82,7 +82,7 @@ Acta Crystallographica, Section C: Crystal Structure Communications;Acta Crystal
 Acta Crystallographica, Section D: Biological Crystallography;Acta Crystallogr., Sect. D: Biol. Crystallogr.
 Acta Crystallographica, Section E: Structure Reports Online;Acta Crystallogr., Sect. E: Struct. Rep. Online
 Acta Crystallographica, Section F: Structural Biology and Crystallization Communications;Acta Crystallogr., Sect. F: Struct. Biol. Cryst. Commun.
-Acta Endocrinologica;Acta Endocrinol.
+Acta Endocrinologica;Acta Endocrinol. (Copenh.)
 Acta Forestalia Fennica;Acta For. Fenn.
 Acta Geodaetica et Geophysica;Acta Geod. Geophys.;;
 Acta Geographica Sinica;Acta Geogr. Sin.
@@ -111,7 +111,7 @@ Acta Polytechnica Scandinavica - Chemical Technology Series;Acta Polytech. Scand
 Acta Protozoologica;Acta Protozool.
 Acta Societatis Botanicorum Poloniae;Acta Soc. Bot. Pol.
 Acta Societatis pro Fauna et Flora Fennica;Acta Soc. Fauna Flora Fenn.
-Acta Theriologica;Acta Theriol.
+Acta Theriologica;Acta Theriol. (Warsz.)
 Acta scientiarum naturalium Academiae scientiarum Bohemoslovaca;Acta sci. nat. Acad. sci. Bohemoslov.
 Actes de la Société helvétique des sciences naturelles;Actes Soc. helv. sci. nat.
 Actes de la Société jurassienne d'émulation;Actes Soc. jura. émul.
@@ -173,8 +173,8 @@ Advances in Mass Spectrometry;Adv. Mass Spectrom.
 Advances in Materials Research;Adv. Mater. Res.
 Advances in Mechanics;Adv. Mech.;;
 Advances in Medical Science;Adv. Med. Sci.;;
-Advances in Modelling and Analysis A;Adv. Modell. Anal. A;;
-Advances in Modelling and Analysis B;Adv. Modell. Anal. B;;
+Advances in Modelling and Analysis A;Adv. Model. Anal. A;;
+Advances in Modelling and Analysis B;Adv. Model. Anal. B;;
 Advances in Molten Salt Chemistry;Adv. Molten Salt Chem.
 Advances in Oceanography and Limnology;Adv. Oceanogr. Limnol.;;
 Advances in OptoElectronics;Adv. OptoElectron.;;
@@ -186,7 +186,7 @@ Advances in Polymer Science;Adv. Polym. Sci.
 Advances in Polymer Technology;Adv. Polym. Technol.
 Advances in Powder Metallurgy;Adv. Powder Metall.
 Advances in Powder Metallurgy and Particulate Materials;Adv. Powder. Metall. Part. Mater.
-Advances in Prostaglandin, Thromboxane, and Leukotriene Research;Adv. Prostaglandin, Thromboxane, Leukotriene Res.
+Advances in Prostaglandin, Thromboxane, and Leukotriene Research;Adv. Prostaglandin. Thromboxane. Leukot. Res.;;
 Advances in Protein Chemistry;Adv. Protein Chem.
 Advances in Quantum Chemistry;Adv. Quantum Chem.
 Advances in Radio Science;Adv. Radio Sci.;;
@@ -307,7 +307,7 @@ Animal Biotelemetry;Anim. Biotelem.;;
 Animal Science and Technology;Anim. Sci. Technol.
 Animal Welfare;Anim. Welfare
 Animal Welfare Information Center Bulletin;Anim. Welfare Inf. Cent. Bull.
-Annalen der Meteorologie;Ann. Meteorol.
+Annalen der Meteorologie;Ann. Meteor.
 Annalen der Schweizerischen meteorologischen Anstalt;Ann. Schweiz. meteorol. Anst.
 Annales Botanici Fennici;Ann. Bot. Fenn.
 Annales Henri Poincaré;Ann. Henri Poincaré;;
@@ -482,7 +482,7 @@ Arealstatistik der Schweiz;Arealstat. Schweiz
 Armyanskii Khimicheskii Zhurnal;Arm. Khim. Zh.
 Arrhythmia & Electrophysiology Review;Arrhythmia Electrophysiol. Rev.;;
 Arteriosclerosis and Thrombosis;Arterioscler. Thromb.
-Arteriosclerosis, Thrombosis, and Vascular Biology;Arterioscler., Thromb., Vasc. Biol.
+Arteriosclerosis, Thrombosis, and Vascular Biology;Arterioscler. Thromb. Vasc. Biol.
 Artificial Cells Blood Substitutes and Immobilization Biotechnology;Artif. Cells, Blood Substitues, Immobilization Biotechnol.
 Arzneimittel Forschung;Arzneim. Forsch.
 Arzneimittel-Forschung/Drug Research;Arzneim.-Forsch.
@@ -612,7 +612,7 @@ Best Practice & Research: Clinical Gastroenterology;Best Pract. Res. Clin. Gastr
 Best Practice & Research: Clinical Haematology;Best Pract. Res. Clin. Haematol.;;
 Best Practice & Research: Clinical Obstetrics and Gynaecology;Best Pract. Res. Clin. Obstet. Gynaecol.;;
 Best Practice & Research: Clinical Rheumatology;Best Pract. Res. Clin. Rheumatol.;;
-Betonwerk und Fertigteil Technik;Betonwerk Fertigteil Tech
+Betonwerk und Fertigteil Technik;Betonwerk Fertigteil Tech.
 Bi-monthly Research Notes;Bi-mon. Res. Notes
 Bibliographia Scientiae Naturalis Helvetica;Bibliogr. Sci. Nat. Helv.
 Bibliotheca Botanica;Bibl. Bot.
@@ -624,7 +624,7 @@ Bilanz;Bilanz
 Bild der Wissenschaft;Bild Wiss.
 Bildmessung und Luftbildwesen;Bildmess. Luftbildwes.
 Bio-Medical Materials and Engineering;Bio-Med. Mater. Eng.
-Bio/Technology;Bio/Technology
+Bio/Technology;Biotechnology. (N. Y.);;
 BioChemistry (Rajkot, India);BioChemistry (Rajkot, India)
 BioEssays;BioEssays
 BioFactors;BioFactors
@@ -750,7 +750,7 @@ Bioremediation Journal;Biorem. J.
 Bioresearch Open Access;Biores. Open Access;;
 Bioresource Technology;Bioresour. Technol.
 Bioscience Reports;Biosci. Rep.
-Bioscience, Biotechnology, and Biochemistry;Biosci., Biotechnol., Biochem.
+Bioscience, Biotechnology, and Biochemistry;Biosci. Biotechnol. Biochem.
 Biosensors & Bioelectronics;Biosens. Bioelectron.
 Biotechnic and Histochemistry;Biotech. Histochem.
 Biotechnologie, Agronomie, Societe et Environnement;Biotechnol. Agron. Soc. Environ.
@@ -996,7 +996,7 @@ Chemical Communications (Cambridge, United Kingdom);Chem. Commun. (Cambridge, U.
 Chemical Education Research and Practice;Chem. Educ. Res. Pract.
 Chemical Engineer (London);Chem. Eng. (London)
 Chemical Engineering & Technology;Chem. Eng. Technol.
-Chemical Engineering (New York);Chem. Eng. (N.Y.)
+Chemical Engineering (New York);Chem. Eng. (N. Y.)
 Chemical Engineering Communications;Chem. Eng. Commun.
 Chemical Engineering Journal;Chem. Eng. J.
 Chemical Engineering Journal (Amsterdam, Netherlands);Chem. Eng. J. (Amsterdam, Neth.)
@@ -1031,7 +1031,7 @@ Chemical and Physical Processes in Combustion;Chem. Phys. Processes Combust.
 Chemicke Listy;Chem. Listy
 Chemicky Prumysl;Chem. Prum.
 Chemico-Biological Interactions;Chem.-Biol. Interact.
-Chemie Anlagen und Verfahren;Chem. -Anlagen Verfahren
+Chemie Anlagen und Verfahren;Chem. Anlagen Verfahren
 Chemie Ingenieur Technik;Chem. Ing. Tech.
 Chemie der Erde;Chem. Erde
 Chemie in unserer Zeit;Chem. unserer Zeit
@@ -1094,7 +1094,7 @@ Chinese Journal of Metal Science & Technology;Chin. J. Met. Sci. Technol.
 Chinese Journal of Nuclear Physics;Chin. J. Nucl. Phys.
 Chinese Journal of Polymer Science;Chin. J. Polym. Sci.
 Chinese Physics;Chin. Phys.
-Chinese Physics B;Chin. Phys. B.
+Chinese Physics B;Chin. Phys. B
 Chinese Physics Letters;Chin. Phys. Lett.
 Chinese Science Bulletin;Chin. Sci. Bull.
 Chirality;Chirality
@@ -1266,8 +1266,8 @@ Current Cancer Drug Targets;Curr. Cancer Drug Targets
 Current Chemical Biology;Curr. Chem. Biol.
 Current Computer-Aided Drug Design;Curr. Comput.-Aided Drug Des.
 Current Drug Abuse Reviews;Curr. Drug Abuse Rev.;;
-Current Drug Delivery;Curr. Drug Delivery
-Current Drug Discovery Technologies;Curr. Drug Discovery Technol.
+Current Drug Delivery;Curr. Drug Deliv.
+Current Drug Discovery Technologies;Curr. Drug Discov. Technol.
 Current Drug Metabolism;Curr. Drug Metab.
 Current Drug Targets;Curr. Drug Targets
 Current Drug Targets: CNS & Neurological Disorders;Curr. Drug Targets: CNS Neurol. Disord.
@@ -1334,7 +1334,7 @@ Czechoslovak Journal of Physics;Czech. J. Phys.
 DECHEMA Biotechnology Conferences;DECHEMA Biotechnol. Conf.
 DNA Repair;DNA Repair
 DNA Research;DNA Res.
-DNA Sequence;DNA Sequence
+DNA Sequence;DNA Seq.
 DNA and Cell Biology;DNA Cell Biol.
 DVS Berichte;DVS Ber.
 Dalton Transactions;Dalton Trans.
@@ -1410,7 +1410,7 @@ Dopovidi Natsional'noi Akademii Nauk Ukraini;Dopov. Nats. Akad. Nauk Ukr.
 Drinking Water Engineering and Science;Drinking Water Eng. Sci.;;
 Drinking Water Engineering and Science Discussions;Drinking Water Eng. Sci. Discuss.;;
 Drug Delivery;Drug Delivery
-Drug Design and Discovery;Drug Des. Discovery
+Drug Design and Discovery;Drug Des. Discov.
 Drug Development Research;Drug Dev. Res.
 Drug Development and Industrial Pharmacy;Drug Dev. Ind. Pharm.
 Drug Discovery and Development;Drug Discovery Dev.
@@ -1462,7 +1462,7 @@ Ecology;Ecology
 Ecology and Society;Ecol. Soc.;;
 Economic Botany;Econ. Bot.
 Economic Geology;Econ. Geol.
-Economic Geology and the Bulletin of the Society of Economic Geologists;Econ. Geol.
+Economic Geology and the Bulletin of the Society of Economic Geologists;Econ. Geol. Bull. Soc. Econ. Geol.;;
 Ecosystem Health and Sustainability;Ecosyst. Health Sustainability;;
 Ecosystem Services;Ecosyst. Serv.;;
 Ecotoxicology and Environmental Safety;Ecotoxicol. Environ. Saf.
@@ -1497,9 +1497,9 @@ Electronic Journal of Operational Meteorology;Electron. J. Oper. Meteorol.;;
 Electronic Journal of Severe Storms Metereology;Electron. J. Severe Storms Metereol.;;
 Electronic Materials Letters;Electron. Mater. Lett.
 Electronic Systems News;Electron. Syst. News;;
-Electronic Technology;Electron Technol.
+Electronic Technology;Electron. Technol.
 Electronics Education;Electron. Educ.;;
-Electronics Letters;Electron. Lett
+Electronics Letters;Electron. Lett.;;
 Electronics and Power;Electron. Power;;
 Electrophoresis;Electrophoresis
 Electrophoresis (Weinheim, Federal Republic of Germany);Electrophoresis (Weinheim, Fed. Repub. Ger.)
@@ -1529,7 +1529,7 @@ Entomologia Experimentalis et Applicata;Entomol. Exp. Appl.
 Entomologische Berichte Luzern;Entomol. Ber. Luzern
 Entomologische Zeitschrift;Entomol. Z.
 Environ. Chem. Preprints of Extended Abstracts presented at the ACS National Meeting, American Chemical Society, Division of Environmental Chemistry;Prepr. Ext. Abstr. ACS Natl. Meet., Am. Chem. Soc., Div.
-Environ. Eng. Journal of Environmental Science and Health, Part A: Toxic/Hazardous Substances & Environmental Engineering;J. Environ. Sci. Health, Part A: Toxic/Hazard. Subst.
+Environ. Eng. Journal of Environmental Science and Health, Part A: Toxic/Hazardous Substances & Environmental Engineering;J. Environ. Sci. Health: Toxic/Hazard. Subst.
 Environment Carcinogenesis and Ecotoxicology Reviews;Environ. Carcinog. Ecotoxicol. Rev.
 Environment International;Environ. Int.
 Environment Protection Engineering;Environ. Prot. Eng.
@@ -1584,10 +1584,10 @@ Esperienze e ricerche;Esper. ric.
 Essays in Biochemistry;Essays Biochem.
 Ettore Majorana International Science Series: Physical Sciences;Ettore Majorana Int. Sci. Ser.: Phys. Sci.
 Etude et Gestion des Sols;Etud. Gest. Sols
-Eukaryotic Cell;Eukaryotic Cell
+Eukaryotic Cell;Eukaryot. Cell
 Eurasian Journal of Analytical Chemistry;Eurasian J. Anal. Chem.
 Eurasian Soil Science;Eurasian Soil Sci.
-European Cytokine Network;Eur. Cytokine Network
+European Cytokine Network;Eur. Cytokine Netw.
 European Food Research and Technology;Eur. Food Res. Technol.
 European Journal of Biochemistry;Eur. J. Biochem.
 European Journal of Cell Biology;Eur. J. Cell Biol.
@@ -1721,8 +1721,8 @@ Floristische Rundbriefe;Florist. Rd.br.
 Flow, Turbulence and Combustion;Flow Turbul. Combust.
 Fluid Phase Equilibria;Fluid Phase Equilib.
 Fluid/Particle Separation Journal;Fluid/Part. Sep. J.
-Folding and Design;Fold Des.
-Folia Biologica;Folia Biol.
+Folding and Design;Fold. Des.
+Folia Biologica;Folia Biol. (Praha)
 Folia Cryptogamica Estonica;Folia Cryptogam. Est.
 Folia Forestalia Polonica;Folia For. Pol.
 Folia Geobotanica et Phytotaxonomica;Folia Geobot. Phytotaxon.
@@ -1770,11 +1770,11 @@ Forêt méditerranéenne;For. méditerr.
 Forêts de France;For. Fr.
 Forêts de France et action forestière;For. Fr. action for.
 Fossil Record;Fossil Rec.;;
-Free Radical Biology & Medicine;Free Radical Biol. Med.
-Free Radical Biology and Medicine;Free Radical Biol. Med.
-Free Radical Research;Free Radical Res.
-Free Radical Research Communications;Free Radical Res. Commun.
-Free Radicals and Antioxidants;Free Radicals Antioxid.;;
+Free Radical Biology & Medicine;Free Radic. Biol. Med.
+Free Radical Biology and Medicine;Free Radic. Biol. Med.
+Free Radical Research;Free Radic. Res.
+Free Radical Research Communications;Free Radic. Res. Commun.
+Free Radicals and Antioxidants;Free Radic. Antioxid.;;
 Freiberger Forschungshefte A.;Freiberg. Forschungsh. A.
 Freiburger Geographische Hefte;Freibg. Geogr. Hefte
 Freiburger Schriften zur Hydrologie;Freibg. Schr. Hydrol.
@@ -1868,7 +1868,7 @@ Gefiederte Welt, Die;Gefied.  Welt
 Gegenbaurs Morphologisches Jahrbuch;Gegenbaurs Morphol. Jahrb.
 Gems & Gemology;Gems Gemol.;;
 Gene;Gene
-Gene Expression Patterns;Gene Expression Patterns
+Gene Expression Patterns;Gene Expr. Patterns
 Gene Therapy;Gene Ther.
 Gene Therapy and Regulation;Gene Ther. Regul.
 General Pharmacology;Gen. Pharmacol.
@@ -1915,11 +1915,11 @@ Geological Magazine;Geol. Mag.
 Geological Society of America Bulletin;Geol. Soc. Am. Bull.
 Geologie en Mijnbouw;Geol. Mijnbouw
 Geologisches Jahrbuch;Geol. Jahrb.
-Geologiya i Geofizika;Geol Geofiz
+Geologiya i Geofizika;Geol. Geofiz.
 Geology;Geology
 Geomagnetizm i Aeronomiya;Geomagn. Aeron.
 Geomicrobiology Journal;Geomicrobiol. J.
-Geophysical Journal;Geophys. J
+Geophysical Journal;Geophys. J.
 Geophysical Magazine;Geophys. Mag.
 Geophysical Prospecting;Geophys. Prospect.
 Geophysical Research Letters;Geophys. Res. Lett.
@@ -1985,7 +1985,7 @@ Hazardous Waste and Hazardous Materials;Hazard. Waste Hazard. Mater.
 Health Physics;Health Phys.
 Heat Transfer Engineering;Heat Transfer Eng.
 Heat Treatment of Metals;Heat Treat. Met.
-Heat and Mass Transfer;Heat Mass Transfer.
+Heat and Mass Transfer;Heat Mass Transfer
 Hecheng Xiangjiao Gongye;Hecheng Xiangjiao Gongye
 Hejishu;Hejishu
 Helgoland Marine Research;Helgol. Mar. Res.;;
@@ -2075,7 +2075,7 @@ Hyperfine Interactions;Hyperfine Interact.
 Hypertension;Hypertension
 Hypertension (Dallas);Hypertension (Dallas)
 IAHS (International Association of Hydrological Sciences) Publication;IAHS Publ.
-IALE (International Association for Landscape Ecology) Bulletin;IALE (International Association for Landscape Ecology) Bull.
+IALE (International Association for Landscape Ecology) Bulletin;IALE Bull.
 IARC Scientific Publications;IARC Sci. Publ.
 IAWA (International Association of Wood Anatomists) Journal;IAWA J.
 IB Scientific Journal of Science;IB Sci. J. Sci.;;
@@ -2374,8 +2374,8 @@ Industrial and Engineering Chemistry, Analytical Edition;Ind. Eng. Chem., Anal. 
 Industrielle Organisation;Ind. Organ.
 Infection and Immunity;Infect. Immun.
 Infectious Disorders: Drug Targets;Infect. Disord.: Drug Targets
-Inflammation & Allergy: Drug Targets;Inflammation Allergy: Drug Targets
-Inflammation Research;Inflammation Res.
+Inflammation & Allergy: Drug Targets;Inflamm. Allergy: Drug Targets
+Inflammation Research;Inflamm. Res.
 Information Professional;Inf. Prof.;;
 Information Report Northern Forest Research Centre;Inf. Rep. North. For. Res. Cent.
 Information Zürcher Wald;Inf. Zür. Wald
@@ -2410,7 +2410,7 @@ Interface Science;Interface Sci.
 Intermetallics;Intermetallics
 International Annual Conference of ICT;Int. Annu. Conf. ICT
 International Aquatic Research;Int. Aquat. Res,;;
-International Archives of Allergy and Immunology;Int. Arch. Allergy Appl. Immunol.
+International Archives of Allergy and Immunology;Int. Arch. Allergy Immunol.
 International Archives of Photogrammetry and Remote Sensing;Int. Arch. Photogramm. Remote Sens.
 International Biodeterioration and Biodegradation;Int. Biodeterior. Biodegrad.
 International Congress Series - Excerpta Medica;Int. Congr. Ser. - Excerpta Med.
@@ -2420,9 +2420,9 @@ International Forest Fire News;Int. For. Fire News
 International Forestry Review;Int. For. Rev.
 International Immunology;Int. Immunol.
 International Immunopharmacology;Int. Immunopharmacol.
-International Journal for Computational Methods in Engineering Science and Mechanics;Int. J. Comput. Methods Eng. Sci Mech.
+International Journal for Computational Methods in Engineering Science and Mechanics;Int. J. Comput. Methods Eng. Sci. Mech.
 International Journal for Numerical Methods in Fluids;Int. J. Numer. Methods Fluids
-International Journal for Simulation and Multidisciplinary Design Optimization;Int. J. Simul. Multi. Design Optim.
+International Journal for Simulation and Multidisciplinary Design Optimization;Int. J. Simul. Multi. Des. Optim.
 International Journal for Vitamin and Nutrition Research;Int. J. Vitam. Nutr. Res.
 International Journal of Adhesion and Adhesives;Int. J. Adhes. Adhes.
 International Journal of Aeronautical and Space Sciences;Int. J. Aeronaut. Space Sci.;;
@@ -2441,7 +2441,7 @@ International Journal of Cardiology-Heart & Vessels;Int. J. Cardiol. Heart Vesse
 International Journal of Cardiology-Metabolic & Endocrine;Int. J. Cardol. Metab. Endocr.;;
 International Journal of Cast Metals Research;Int. J. Cast Met. Res.
 International Journal of Chemical Kinetics;Int. J. Chem. Kinet.
-International Journal of Chemical Reactor Engineering;Int. J. Chem. Reactor Eng. ??
+International Journal of Chemical Reactor Engineering;Int. J. Chem. Reactor Eng.
 International Journal of Chemical and Analytical Science;Int. J. Chem. Anal. Sci.;;
 International Journal of Chemistry;Int. J. Chem.
 International Journal of Child-Computer Interaction;Int. J. Child-Comput. Interact.;;
@@ -2474,7 +2474,7 @@ International Journal of Heat and fluid flow;Int. J. Heat Fluid Flow
 International Journal of Hydrogen Energy;Int. J. Hydrogen Energy
 International Journal of Immunogenetics;Int. J. Immunogenet.
 International Journal of Immunopathology and Pharmacology;Int.. J. Immunopathol. Pharmacol.;;
-International Journal of Immunopharmacology;Int. J. Immunopharmacol
+International Journal of Immunopharmacology;Int. J. Immunopharmacol.
 International Journal of Impact Engineering;Int. J. Impact Eng.
 International Journal of Infrared and Millimeter Waves;Int. J. Infrared Millimeter Waves
 International Journal of Inorganic Materials;Int. J. Inorg. Mater.
@@ -2489,8 +2489,8 @@ International Journal of Multiphase Flow;Int. J. Multiphase Flow
 International Journal of Multiphysics;Int. J. Multiphys.
 International Journal of Nanoscience;Int. J. Nanosci.
 International Journal of Non-Equilibrium Processing;Int. J. Non-Equilib. Process.
-International Journal of Nonlinear Modelling in Science and Engineering;Int. J. Nonlinear Modell. Sci. Eng.;;
-International Journal of Nonlineare Modelling in Science and Engineering;Int. J. Nonlinear Modell. Sci. Eng.
+International Journal of Nonlinear Modelling in Science and Engineering;Int. J. Nonlinear Model. Sci. Eng.;;
+International Journal of Nonlineare Modelling in Science and Engineering;Int. J. Nonlinear Model. Sci. Eng.
 International Journal of Oncology;Int. J. Oncol.
 International Journal of PIXE;Int. J. PIXE
 International Journal of Paleopathology;Int. J. Paleopathol.;;
@@ -2669,7 +2669,7 @@ Journal of Applied Research on Medicinal and Aromatic Plants;J. Appl. Res. Med. 
 Journal of Applied Spectroscopy;J. Appl. Spectrosc.
 Journal of Applied Toxicology;J. Appl. Toxicol.
 Journal of Archaeological Science;J. Archaeol. Sci.
-Journal of Archaeological Science: Reports;J. Archaeolog. Sci.: Rep.;;
+Journal of Archaeological Science: Reports;J. Archaeol. Sci.: Rep.;;
 Journal of Asia-Pacific Biodiversity;J. Asia-Pac. Biodivers.;;
 Journal of Asian Ceramic Societies;J. Asian Ceram. Soc.;;
 Journal of Asian Natural Products Research;J. Asian Nat. Prod. Res.
@@ -2696,7 +2696,7 @@ Journal of Biological Inorganic Chemistry;J. Biol. Inorg. Chem.
 Journal of Biological Research-Thessaloniki;J. Biol. Res. Thessaloniki;;
 Journal of Bioluminescence and Chemiluminescence;J. Biolumin. Chemilumin.
 Journal of Biomaterials Applications;J. Biomater. Appl.
-Journal of Biomaterials Science, Polymer Edition;J. Biomater. Sci., Polym. Ed.
+Journal of Biomaterials Science, Polymer Edition;J. Biomater. Sci. Polym. Ed.
 Journal of Biomechanical Engineering;J. Biomech. Eng.
 Journal of Biomedial Materials Research;J. Biomed. Mater. Res.
 Journal of Biomedial Materials ResearchPart A;J. Biomed. Mater. Res. Part A;;
@@ -2747,7 +2747,7 @@ Journal of Chromatography;J. Chromatogr.
 Journal of Chromatography, A;J. Chromatogr., A
 Journal of Chromatography, B: Analytical Technologies in the Biomedical and Life Sciences;J. Chromatogr., B: Anal. Technol. Biomed. Life Sci.
 Journal of Circadian Rhythms;J. Circadian Rhythms;;
-Journal of Climate;J. Clim.
+Journal of Climate;J. Climate
 Journal of Climate and Applied Meteorology;J. Clim. Appl. Meteorol.
 Journal of Clinical Bioinformatics;J. Clin. Bioinf.;;
 Journal of Clinical Endocrinology and Metabolism;J. Clin. Endocrinol. Metab.
@@ -2776,7 +2776,7 @@ Journal of Computational and Graphical Statistics;J. Comput. Graph. Stat.
 Journal of Computational and Nonlinear Dynamics;J. Comput. Nonlinear Dyn.
 Journal of Computational and Theoretical Nanoscience;J. Comput. Theor. Nanosci.
 Journal of Computer Chemistry, Japan;J. Comput. Chem., Jpn.
-Journal of Computer-Aided Materials Design;J. Comput. Aided Mater. Des.
+Journal of Computer-Aided Materials Design;J. Comput.-Aided Mater. Des.
 Journal of Computer-Aided Molecular Design;J. Comput.-Aided Mol. Des.
 Journal of Computing Science and Engineering;J. Comput. Sci. Eng.;;
 Journal of Contaminant Hydrology;J. Contam. Hydrol.
@@ -2871,7 +2871,7 @@ Journal of Forensic Medicine;J. Forensic Med.
 Journal of Forensic Medicine and Toxicology;J. Forensic Med. Toxicol.
 Journal of Forensic Radiology and Imaging;J. Forensic Radiol. Imaging;;
 Journal of Forensic Science;J. Forensic Sci.
-Journal of Forensic and Legal Medicine;J. Forensic Legal Med.;;
+Journal of Forensic and Legal Medicine;J. Forensic Leg. Med.;;
 Journal of Forestry;J. For.
 Journal of Freshwater Ecology;J. Freshwater Ecol.;;
 Journal of Fusion Energy;J. Fusion Energy
@@ -2884,13 +2884,13 @@ Journal of Geochemical Exploration;J. Geochem. Explor.
 Journal of Geological Education;J. Geol. Educ.
 Journal of Geology;J. Geol.
 Journal of Geophysical Research;J. Geophys. Res.
-Journal of Geophysical Research, A: Space Physics;J. Geophys. Res., A: Space Phys.
-Journal of Geophysical Research, B: Solid Earth;J. Geophys. Res., B: Solid Earth
-Journal of Geophysical Research, C: Oceans;J. Geophys. Res., C: Oceans
-Journal of Geophysical Research, D: Atmospheres;J. Geophys. Res., D: Atmos.
-Journal of Geophysical Research, E: Planets;J. Geophys. Res., E: Planets
-Journal of Geophysical Research, F: Earth Surface;J. Geophys. Res., F: Earth Surface
-Journal of Geophysical Research, G: Biogeosciences;J. Geophys. Res., G: Biogeosci.
+Journal of Geophysical Research, A: Space Physics;J. Geophys. Res. A: Space Phys.
+Journal of Geophysical Research, B: Solid Earth;J. Geophys. Res. B: Solid Earth
+Journal of Geophysical Research, C: Oceans;J. Geophys. Res. C: Oceans
+Journal of Geophysical Research, D: Atmospheres;J. Geophys. Res. D: Atmos.
+Journal of Geophysical Research, E: Planets;J. Geophys. Res. E: Planets
+Journal of Geophysical Research, F: Earth Surface;J. Geophys. Res. F: Earth Surface
+Journal of Geophysical Research, G: Biogeosciences;J. Geophys. Res. G: Biogeosci.
 Journal of Geophysical Research, [Atmospheres];J. Geophys. Res. [Atmos.]
 Journal of Geophysical Research, [Biogeosciences];J. Geophys. Res. [Biogeosci.]
 Journal of Geophysical Research, [Earth Surface];J. Geophys. Res. [Earth Surface]
@@ -2969,8 +2969,8 @@ Journal of Macromolecular Science, Physics;J. Macromol. Sci., Phys.
 Journal of Macromolecular Science, Polymer Reviews;J. Macromol. Sci., Polym. Rev.
 Journal of Macromolecular Science, Pure and Applied Chemistry;J. Macromol. Sci., Pure Appl. Chem.
 Journal of Magnetic Resonance;J. Magn. Reson.
-Journal of Magnetic Resonance Series A;J. Magn. Reson., Ser A
-Journal of Magnetic Resonance Series B;J. Magn. Reson., Ser B
+Journal of Magnetic Resonance Series A;J. Magn. Reson. A
+Journal of Magnetic Resonance Series B;J. Magn. Reson. B
 Journal of Magnetism and Magnetic Materials;J. Magn. Magn. Mater.
 Journal of Mammalogy;J. Mammal.
 Journal of Mass Spectrometry;J. Mass Spectrom.
@@ -3020,7 +3020,7 @@ Journal of Molecular Catalysis A: Chemical;J. Mol. Catal. A: Chem.
 Journal of Molecular Catalysis B: Enzymatic;J. Mol. Catal. B: Enzym.
 Journal of Molecular Endocrinology;J. Mol. Endocrinol.
 Journal of Molecular Evolution;J. Mol. Evol.
-Journal of Molecular Graphics & Modelling;J. Mol. Graphics Modell.
+Journal of Molecular Graphics & Modelling;J. Mol. Graphics Model.
 Journal of Molecular Liquids;J. Mol. Liq.
 Journal of Molecular Microbiology and Biotechnology;J. Mol. Microbiol. Biotechnol.
 Journal of Molecular Modeling;J. Mol. Model.
@@ -3055,9 +3055,9 @@ Journal of Non-Crystalline Solids;J. Non-Cryst. Solids
 Journal of Non-Equilibrium Thermodynamics;J. Non-Equilib. Thermodyn.
 Journal of Non-Newtonian Fluid Mechanics;J. Non-Newtonian Fluid Mech.
 Journal of Nuclear Energy;J. Nuclear Eng.
-Journal of Nuclear Energy, Part A: Reactor Science;J. Nuclear Eng. Part A:
-Journal of Nuclear Energy, Part B: Reactor Technology;J. Nuclear Eng. Part B:
-Journal of Nuclear Energy, Part C: Plasma Physics, Accelerators, Thermonuclear Research;J. Nuclear Eng. Part C:
+Journal of Nuclear Energy, Part A: Reactor Science;J. Nucl. Energy A
+Journal of Nuclear Energy, Part B: Reactor Technology;J. Nucl. Energy B
+Journal of Nuclear Energy, Part C: Plasma Physics, Accelerators, Thermonuclear Research;J. Nuclear Energy C
 Journal of Nuclear Materials;J. Nucl. Mater.
 Journal of Nuclear Science and Technology;J. Nucl. Sci. Technol.
 Journal of Nuclear Science and Technology (Tokyo, Japan);J. Nucl. Sci. Technol. (Tokyo, Jpn.)
@@ -3115,7 +3115,7 @@ Journal of Physics B: Atomic, Molecular and Optical Physics;J. Phys. B: At., Mol
 Journal of Physics C: Solid State Physics;J. Phys. C: Solid State Phys.
 Journal of Physics D: Applied Physics;J. Phys. D: Appl. Phys.
 Journal of Physics E: Scientific Instruments;J. Phys. E: Sci. Instrum.
-Journal of Physics F: Metal Physics;J. Phys, F: Met. Phys.
+Journal of Physics F: Metal Physics;J. Phys F: Met. Phys.
 Journal of Physics G: Nuclear and Particle Physics;J. Phys. G: Nucl. Part. Phys.
 Journal of Physics and Chemistry of Solids;J. Phys. Chem. Solids
 Journal of Physics: Condensed Matter;J. Phys.: Condens. Matter
@@ -3208,20 +3208,20 @@ Journal of Theoretical Biology;J. Theor. Biol.
 Journal of Therapeutic Ultrasound;J. Ther. Ultrasound;;
 Journal of Thermal Analysis;J. Therm. Anal.
 Journal of Thermal Analysis and Calorimetry;J. Therm. Anal. Calorim.
-Journal of Thermal Science and Technology;J. Them. Sci. Technol.
+Journal of Thermal Science and Technology;J. Therm. Sci. Technol.
 Journal of Thermal Spray Technology;J. Therm. Spray Technol.
 Journal of Thermophysics and Heat Transfer;J. Thermophys. Heat Transfer
 Journal of Thermoplastic Composite Materials;J. Thermoplast. Compos. Mater.
 Journal of Time Series Analysis;J. Time Ser. Anal.
 Journal of Tissue Engineering and Regenerative Medicine;J. Tissue Eng. Regener. Med.;;
-Journal of Toxicology - Clinical Toxicology;J. Toxicol., Clin. Toxicol.
-Journal of Toxicology - Cutaneous and Ocular Toxicology;J. Toxicol., Cutaneous Ocul. Toxicol.
-Journal of Toxicology - Toxin Reviews;J. Toxicol., Toxin Rev.
+Journal of Toxicology - Clinical Toxicology;J. Toxicol. Clin. Toxicol.
+Journal of Toxicology - Cutaneous and Ocular Toxicology;J. Toxicol. Cutaneous Ocul. Toxicol.
+Journal of Toxicology - Toxin Reviews;J. Toxicol. Toxin Rev.
 Journal of Toxicology and Environmental Health;J. Toxicol. Environ. Health
 Journal of Toxicology and Environmental Health, Part A;J. Toxicol. Environ. Health, Part A
 Journal of Toxicology and Environmental Health, Part B: Critical Reviews;J. Toxicol. Environ. Health, Part B
 Journal of Trace Elements in Experimental Medicine;J. Trace Elem. Exp. Med.
-Journal of Trace Elements in Medicine and Biology;J. Trace Elem. Med Biol.
+Journal of Trace Elements in Medicine and Biology;J. Trace Elem. Med. Biol.
 Journal of Trace and Microprobe Techniques;J. Trace Microprobe Tech.
 Journal of Tropical Ecology;J. Trop. Ecol.
 Journal of Tropical Forest Science;J. Trop. For. Sci.;;
@@ -3489,9 +3489,9 @@ Magyar Kemikusok Lapja;Magy. Kem. Lapja
 Main Group Chemistry;Main Group Chem.
 Main Group Metal Chemistry;Main Group Met. Chem.
 Makromolekulare Chemie;Makromol. Chem.
-Makromolekulare Chemie, Macromolecular Symposia;Makromol. Chem., Macromol. Symp.
-Makromolekulare Chemie, Rapid Communications;Makromol. Chem., Rapid Commun.
-Makromolekulare Chemie, Supplement;Makromol. Chem., Suppl.
+Makromolekulare Chemie, Macromolecular Symposia;Makromol. Chem. Macromol. Symp.
+Makromolekulare Chemie, Rapid Communications;Makromol. Chem. Rapid Commun.
+Makromolekulare Chemie, Supplement;Makromol. Chem. Suppl.
 Malayan Journal of Tropical Geography;Malayan J. Trop. Geogr.
 Malayan Nature Journal, The;Malayan Nat. J.
 Malaysian Forester, The;Malays. For.
@@ -3615,7 +3615,7 @@ Meteorologische Zeitschrift;Meteorol. Z.
 Meteorology and Atmospheric Physics;Meteorol. Atmos. Phys.
 Methods (Oxford, United Kingdom);Methods (Oxford, U. K.)
 Methods (San Diego, CA, United States);Methods (San Diego, CA, U. S.)
-Methods and Findings in Experimental and Clinical Pharmacology;Methods Finds Exp. Clin. Pharmacol.
+Methods and Findings in Experimental and Clinical Pharmacology;Methods Find. Exp. Clin. Pharmacol.
 Methods in Ecology and Evolution;Methods Ecol. Evol.;;
 Methods in Enzymology;Methods Enzymol.
 Methods of Biochemical Analysis;Methods Biochem. Anal.
@@ -3649,7 +3649,7 @@ Milchwissenschaft;Milchwissenschaft
 Mine Water and the Environment;Mine Water Environ.
 Mineral Processing and Extractive Metallurgy Review;Miner. Process. Extr. Metall. Rev.
 Mineralium Deposita;Miner. Deposita
-Mineralogical Magazine;Mineralog. Mag.
+Mineralogical Magazine;Mineral. Mag.
 Mineralogical Record;Mineral. Rec.;;
 Mineralogicheskii Zhurnal;Mineral. Zh.
 Mineralogy and Petrology;Mineral. Petrol.
@@ -3699,7 +3699,7 @@ Mitteilungen des Historischen Vereins des Kantons Schwyz;Mitt. Hist. Ver. Kanton
 Mitteilungen des Kuratoriums für Waldarbeit und Forsttechnik;Mitt. Kurat. Waldarb. Forsttech.
 Mitteilungen des Vereins für forstliche Standortskunde und Forstpflanzenzüchtung;Mitt. Ver. forstl. Standortskd. Forstpflanzenzücht.
 Mitteilungsblatt - Chemische Gesellschaft der Deutschen Demokratischen Republik;Mitteilungsbl. - Chem. Ges. D. D. R.;;
-Modelling and Simulation in Materials Science and Engineering;Modell. Simul. Mater. Sci. Eng.
+Modelling and Simulation in Materials Science and Engineering;Model. Simul. Mater. Sci. Eng.
 Modern Drug Discovery;Mod. Drug Discovery
 Modern Physics Letters A;Mod. Phys. Lett. A
 Modern Physics Letters B;Mod. Phys. Lett. B
@@ -3731,7 +3731,7 @@ Molecular Genetics and Metabolism;Mol. Genet. Metab.
 Molecular Genetics and Metabolism Reports;Mol. Genet. Metab. Rep.;;
 Molecular Immunology;Mol. Immunol.
 Molecular Interventions;Mol. Interventions
-Molecular Marine Biology and Biotechnology;Mol. Mar. Biol. Biotech.
+Molecular Marine Biology and Biotechnology;Mol. Mar. Biol. Biotechnol.
 Molecular Membrane Biology;Mol. Membr. Biol.
 Molecular Microbiology;Mol. Microbiol.
 Molecular Neurobiology;Mol. Neurobiol.
@@ -3780,13 +3780,13 @@ Mutation Research, DNA Repair;Mutat. Res. DNA Repair;;
 Mutation Research, DNA Repair Reports;Mutat. Res. DNA Repair Rep.;;
 Mutation Research, DNAging: Genetic Instability and Aging;Mutat. Res. DNAging: Genet. Instab. Aging;;
 Mutation Research, Environmental Mutagenesis and Related Subjects;Mutat. Res. Environ. Mutagen. Relat. Subj.;;
-Mutation Research, Fundamental and Molecular Mechanisms of Mutagenesis;Mutat. Res., Fundam. Mol. Mech. Mutagen.
+Mutation Research, Fundamental and Molecular Mechanisms of Mutagenesis;Mutat. Res. Fundam. Mol. Mech. Mutagen.
 Mutation Research, Genetic Toxicology;Mutat. Res. Genet. Toxicol.;;
 Mutation Research, Genetic Toxicology Testing;Mutat. Res. Genet. Toxicol. Test.;;
-Mutation Research, Genetic Toxicology and Environmental Mutagenesis;Mutat. Res., Genet. Toxicol. Environ. Mutagen.
+Mutation Research, Genetic Toxicology and Environmental Mutagenesis;Mutat. Res. Genet. Toxicol. Environ. Mutagen.;;
 Mutation Research, Mutation Research Genomics;Mutat. Res. Mutat. Res. Genomics;;
 Mutation Research, Reviews in Genetic Toxicology;Mutat. Res. Rev. Genet. Toxicol.;;
-Mutation Research, Reviews in Mutation Research;Mutat. Res., Rev. Mutat. Res.
+Mutation Research, Reviews in Mutation Research;Mutat. Res. Rev. Mutat. Res.
 Mycologia;Mycologia
 Mycologia Balcanica;Mycol. Balc.
 Mycologia Helvetica;Mycol. Helv.
@@ -3892,11 +3892,11 @@ Naturopa;Naturopa
 Naturschutz heute;Nat.schutz heute
 Naturschutz und Landschaftspflege in Hamburg;Nat.schutz Landsch.pfl. Hambg.
 Naturschutz und Landschaftspflege in Niedersachsen;Nat.schutz Landsch.pfl. Niedersachs.
-Naturschutz und Landschaftsplanung;Nat.schutz Landsch.plan.
+Naturschutz und Landschaftsplanung;Naturschutz Landschaftsplan.;;
 Naturwissenschaft im Unterricht Chemie;Naturwiss. Unterr. Chem.
 Naturwissenschaften;Naturwissenschaften
 Naturwissenschaften, Die;Naturwissenschaften
-Naturwissenschaftliche Rundschau;Nat.wiss. Rundsch.
+Naturwissenschaftliche Rundschau;Naturwiss. Rundschau;;
 Naunyn-Schmiedeberg's Archives of Pharmacology;Naunyn-Schmiedeberg's Arch. Pharmacol.
 Near Surface Geophysics;Near Surf. Geophys.;;
 Nederlands Bosbouw-Tijdschrift;Ned. Bosb.-Tijdschr.
@@ -3944,7 +3944,7 @@ New Journal of Physics;New J. Phys.
 New Microbes New Infections;New Microbes New Infect.;;
 New Negatives in Plant Science;New Negat. Plant Sci.;;
 New Phytologist;New Phytol.
-New Polymeric Materials;New Polym. Mat.
+New Polymeric Materials;New Polym. Mater.
 New Scientist;New Sci.
 New Zealand Geographer;N. Z. Geogr.;;
 New Zealand Journal of Botany;N. Z. J. Bot.
@@ -3967,7 +3967,7 @@ Nippon Shokuhin Kogyo Gakkaishi;Nippon Shokuhin Kogyo Gakkaishi
 Nippon Suisan Gakkaishi;Nippon Suisan Gakkaishi
 Nippon Yakurigaku Zasshi;Nippon Yakurigaku Zasshi
 Nitric Oxide;Nitric Oxide
-Nonlinear Analysis: Modeling and Control;Nonlinear Anal. Modell. Control;;
+Nonlinear Analysis: Modeling and Control;Nonlinear Anal. Model. Control;;
 Nonlinear Processes in Geophysics Discussions;Nonlinear Processes Geophys. Discuss.;;
 Nordic Hydrology;Nord. Hydrol.
 Nordic Journal of Botany;Nord. J. Bot.
@@ -4020,7 +4020,7 @@ Oceanus;Oceanus
 Oecologia;Oecologia
 Oekologia Plantarum;Oekol. Plant.
 Oekologie der Vögel;Oekol. Vögel
-Oesterreichische Wasser- und Abfallwirtschaft;Oesterr. Wasser- Abfallwirtsch.
+Österreichische Wasser- und Abfallwirtschaft;Österr. Wasser- Abfallwirtsch.
 Ogneupory;Ogneupory
 Oikos;Oikos
 Oil and Gas Journal;Oil Gas J.
@@ -4094,12 +4094,11 @@ PLOS Currents: Huntington Disease;PLOS Curr.: Huntington Dis.;;
 PLOS Currents: Muscular Dystrophy;PLOS Curr.: Muscular Dystrophy;;
 PLOS Currents: Outbreaks;PLOS Curr.: Outbreaks;;
 PLOS Currents: Tree of Life;PLOS Curr.: Tree Life;;
-PLOS ONE;PLoS One;;
-PLoS Biology;PLoS Biol.
-PLoS Computational Biology;PLoS Comput. Biol.
-PLoS Genetics;PLoS Genet.
-PLoS One;PLoS One
-PLoS Pathogens;PLoS Pathog.
+PLOS ONE;PLOS One;;
+PLOS Biology;PLOS Biol.
+PLOS Computational Biology;PLOS Comput. Biol.
+PLOS Genetics;PLOS Genet.
+PLOS Pathogens;PLOS Pathog.
 PMSE Preprints;PMSE Prepr.
 Pacific Science;Pac. Sci.
 Pacific Science Review;Pac. Sci. Rev.;;
@@ -4137,7 +4136,7 @@ Perspectives in Science;Perspect. Sci.;;
 Pertanika Journal of Tropical Agricultural Science;Pertanika J. Trop. Agric. Sci.;;
 Pervasive Computing;Pervasive Comput.
 Pesquisa Agropecuária Brasileira;Pesqui. Agropecu. Bras.
-Pest Management Science;Pest Manage. Sci.
+Pest Management Science;Pest Manag. Sci.
 Pesticide Biochemistry and Physiology;Pestic. Biochem. Physiol.
 Pesticide Outlook;Pestic. Outlook
 Pesticide Science;Pestic. Sci.
@@ -4391,7 +4390,6 @@ Proceedings of the International Pyrotechnics Seminar;Proc. Int. Pyrotech. Semin
 Proceedings of the International Symposium on Boreal Forest;Proc. Int. Symp. Boreal For.
 Proceedings of the Intersociety Energy Conversion Engineering Conference;Proc. Intersoc. Energy Convers. Eng. Conf.
 Proceedings of the Linnean Society of New South Wales;Proc. Linn. Soc. N. S. W.
-Proceedings of the National Academy of Science of the United States of America;Proc. Natl. Acad. Sci. U.S.A.
 Proceedings of the National Academy of Sciences of the United States of America;Proc. Natl. Acad. Sci. U.S.A.
 Proceedings of the National Academy of Sciences of the United States of America, Early Edition;Proc. Natl. Acad. Sci. U.S.A., Early Ed.
 Proceedings of the National Academy of Sciences, India, Section A: Physical Sciences;Proc. Natl. Acad. Sci., India, Sect. A
@@ -4401,10 +4399,10 @@ Proceedings of the Physical Society. Section B;Proc. Phys. Soc. London, Sect. B
 Proceedings of the Prehistoric Society;Proc. Prehist. Soc;;
 Proceedings of the Royal Irish Academy;Proc. R. Ir. Acad.
 Proceedings of the Royal Society of London. Series A;Proc. R. Soc. London, Ser. A.
-Proceedings of the Royal Society of London. Series A - Mathematical and Physical Sciences;Proc. R. Soc. London, Ser. A Math Phys. Sci.
-Proceedings of the Royal Society of London. Series A, Containing Papers of a Mathematical and Physical Character;Proc. R. Soc. London, Ser. A.
-Proceedings of the Royal Society of London. Series B;Proc. R. Soc. London, Ser. B
-Proceedings of the Royal Society of London. Series B: Biological Sciences;Proc. R. Soc. London, Ser. B
+Proceedings of the Royal Society of London. Series A - Mathematical and Physical Sciences;Proc. R. Soc. London A - Math Phys. Sci.
+Proceedings of the Royal Society of London. Series A, Containing Papers of a Mathematical and Physical Character;Proc. R. Soc. London A.
+Proceedings of the Royal Society of London. Series B;Proc. R. Soc. London B
+Proceedings of the Royal Society of London. Series B: Biological Sciences;Proc. R. Soc. Lond. B Biol. Sci.;;
 Proceedings of the SPI Annual Technical/Marketing Conference;Proc. SPI Annu. Tech./Mark. Conf.
 Proceedings of the Society for Experimental Biology and Medicine;Proc. Soc. Exp. Biol. Med.
 Proceedings of the Soil Science Society of America;Proc. Soil Sci. Soc. Am.
@@ -4557,7 +4555,7 @@ Regenerative Engineering and Translational Medicine;Regener. Eng. Transl. Med.;;
 Regio Basiliensis;Reg. Basil.
 Regional Environmental Change;Reg. Environ. Change
 Regulatory Peptides;Regul. Pept.
-Regulatory Toxicology and Pharmacology;Regul. Toxicol. Pharm.
+Regulatory Toxicology and Pharmacology;Regul. Toxicol. Pharmacol.
 Reinforced Plastics;Reinf. Plast.
 Reinforced Plastics and Composites World;Reinf. Plast. Compos. World
 Reliability Engineering;Reliab. Eng.;;
@@ -4886,6 +4884,10 @@ Studies in Surface Science and Catalysis;Stud. Surf. Sci. Catal.
 Studies on Tropical Andean Ecosystems;Stud. Trop. Andean Ecosyst.
 Stuttgarter Beiträge zur Naturkunde;Stuttg. Beitr. Nat.kd.
 Subj. Biochimica et Biophysica Acta, Specialized Section on Nucleic Acids and Related Subjects;Biochim. Biophys. Acta, Spec. Sect. Nucleic Acids Relat.
+Sudhoffs Archiv. Vierteljahresschrift fur Geschichte der Medizin und der Naturwissenschaften, der Pharmazie und der Mathematik;Sudhoffs Arch., Vierteljahresschr. fur Gesch. Med. Naturwiss. Pharm. Math.;;
+Sudhoffs Archiv für Geschichte der Medizin;Sudhoffs Arch. Gesch. Med.;;
+Sudhoffs Archiv für Geschichte der Medizin und der Naturwissenschaften;Sudhoffs Arch. Gesch. Med. Naturwiss.;;
+Sudhoffs Archiv. Zeitschrift für Wissenschaftsgeschichte;Sudhoffs Arch., Z. Wissenschaftsgesch.;;
 Sulfur Letters;Sulfur Lett.
 Superconductor Science & Technology;Supercond. Sci. Technol.
 Superconductor Science and Technology;Supercond. Sci. Technol.
@@ -5201,6 +5203,7 @@ Water, Air and Soil Pollution;Water Air Soil Pollut.
 Water, Air, & Soil Pollution;Water, Air, Soil Pollut.
 Wear;Wear
 Weather and Climate Extremes;Weather Clim. Extremes;;
+Weather and Forecasting;Weather Forecast.;;
 Weather, Climate, and Society;Weather Clim. Soc.;;
 Web Ecology;Web Ecol.;;
 Weed Science;Weed Sci.
@@ -5255,6 +5258,7 @@ Yosetsu Gakkai Ronbunshu;Yosetsu Gakkai Ronbunshu
 Youji Huaxue;Youji Huaxue
 Yukagaku;Yukagaku
 Yuki Gosei Kagaku Kyokaishi;Yuki Gosei Kagaku Kyokaishi
+ZFA - Zeitschrift für Allgemeinmedizin;ZFA - Z. Allgemeinmed.;;
 Zairyo;Zairyo
 Zapiski Vsesoyuznogo Mineralogicheskogo Obshchestva;Zap. Vses. Mineral. O-va.
 Zashchita Metallov;Zashch. Met.

--- a/journals/journal_abbreviations_geology_physics.csv
+++ b/journals/journal_abbreviations_geology_physics.csv
@@ -932,7 +932,7 @@ Philosophical Transactions of the Royal Society A;Philos. Trans. R. Soc. A
 Philosophical Transactions of the Royal Society;Philos. Trans. R. Soc.
 Phosphorus Sulfur Silicon and the Related Elements;Phosphorus, Sulfur Silicon Relat. Elem.
 Phosphorus Sulfur and Related Elements;Phosphorus Sulfur Rel. Elem.
-Photonics Research;Photon. Res.
+Photonics Research;Photonics Res.
 Physica (Utrecht);Physica (Utrecht)
 Physica A;Phys. A
 Physica B: Condensed Matter;Phys. B: Condens. Matter

--- a/journals/journal_abbreviations_geology_physics.csv
+++ b/journals/journal_abbreviations_geology_physics.csv
@@ -50,7 +50,7 @@ Advances in Atomic and Molecular Physics;Adv. At. Mol. Phys.
 Advances in Chemical Physics;Adv. Chem. Phys.
 Advances in Fluid Mechanics;Adv. Fluid Mech.
 Advances in Magnetic Resonance;Adv. Magn. Reson.
-Advances in Natural Sciences: Nanoscience and Nanotechnology;Adv. Nat. Sci: Nanosci. Nanotechnol.
+Advances in Natural Sciences: Nanoscience and Nanotechnology;Adv. Nat. Sci.: Nanosci. Nanotechnol.
 Advances in Nuclear Physics;Adv. Nucl. Phys.
 Advances in Optics and Photonics;Adv. Opt. Photonics
 Advances in Physics;Adv. Phys.
@@ -98,7 +98,7 @@ Applied Geochemistry;Appl. Geochem.
 Applied Geography;Appl. Geogr.
 Applied Geophysics;Appl. Geophys.
 Applied Materials Today;Appl. Mater. Today
-Applied Mathematical Modelling;Appl. Math. Modell.
+Applied Mathematical Modelling;Appl. Math. Model.
 Applied Mathematics Letters;Appl. Math. Lett.
 Applied Mathematics and Computation;Appl. Math. Comput.
 Applied Mechanics Reviews;Appl. Mech. Rev.
@@ -139,7 +139,7 @@ Australian Journal of Grape and Wine Research;Aust. J. Grape Wine Res.
 Australian Journal of Physics;Aust. J. Phys.
 BMR Journal of Geology and Geophysics;BMR J. Aust. Geol. Geophys.
 Basin Research;Basin Res.
-Bayer CropScience Journal;Bayer CropSci J.
+Bayer CropScience Journal;Bayer CropSci. J.
 Beilstein Journal of Nanotechnology;Beilstein J. Nanotechnol.
 Beiträge Zur Physik der Atmosphäre;Beitr. Zur Phys. Atmos.
 Bell Laboratories Record;Bell Lab. Rec.
@@ -331,7 +331,7 @@ Geomagnetism and Aeronomy;Geomag. Aeron.
 Geomechanics and Geoengineering;Geomech. Geoeng.
 Geomechanics and Tunnelling;Geomech. Tunnelling
 Geophysical Journal International;Geophys. J. Int.
-Geophysical Journal;Geophys. J
+Geophysical Journal;Geophys. J.
 Geophysical Magazine;Geophys. Mag.
 Geophysical Prospecting;Geophys. Prospect.
 Geophysical Research Letters;Geophys. Res. Lett.
@@ -355,7 +355,7 @@ Helvetica Physica Acta;Helv. Phys. Acta
 High Temperature (USSR) [translation of Teplofizika Vysokikh Temperatur];High Temp. (USSR)
 Himalayan Geology;Himalayan Geol.
 Hydrogeology Journal;Hydrol. J.
-Hydrological Processes;Hydrol. Processes
+Hydrological Processes;Hydrol. Process.
 Hydrological Sciences Bulletin;Hydrol. Sci. Bull.
 Hydrological Sciences Journal;Hydrol. Sci. J.
 Hyperfine Interactions;Hyperfine Interact.
@@ -429,7 +429,7 @@ International Journal of Fracture;Int. J. Fract.
 International Journal of Fuzzy Systems;Int. J. Fuzzy Syst.
 International Journal of General Systems;Int. J. Gen. Syst.
 International Journal of Geomechanics;Int. J. Geomech.
-International Journal of Geometric Methods in Modern Physics;Int. J. Geom. Meth. Mod. Phys.
+International Journal of Geometric Methods in Modern Physics;Int. J. Geom. Methods Mod. Phys.
 International Journal of Grid and Utility Computing;Int. J. Grid Util. Comput.
 International Journal of Heat Exchangers;Int. J. Heat Exch.
 International Journal of Heat and Fluid Flow;Int. J. Heat Fluid Flow
@@ -439,7 +439,7 @@ International Journal of High Performance Computing Applications;Int. J. High Pe
 International Journal of High Performance Computing and Networking;Int. J. High Perform. Comput. Networking
 International Journal of High Performance Systems Architecture;Int. J. High Perform. Syst. Archit.
 International Journal of Hydrogen Energy;Int. J. Hydrog. Energy
-International Journal of Immunopharmacology;Int. J. Immunopharmacol
+International Journal of Immunopharmacology;Int. J. Immunopharmacol.
 International Journal of Information Quality;Int. J. Inf. Qual.
 International Journal of Information Security;Int. J. Inf. Secur.
 International Journal of Innovative Computing and Applications;Int. J. Innovative Comput. Appl.
@@ -567,7 +567,7 @@ Journal of Computational and Applied Mathematics;J. Comput. Appl. Math.
 Journal of Contemporary Physics;J. Contemp. Phys.
 Journal of Cosmology and Astroparticle Physics;J. Cosmol. Astropart. Phys.
 Journal of Crystal Growth;J. Cryst. Growth
-Journal of Display Technology;J. Display Technol.
+Journal of Display Technology;J. Disp. Technol.
 Journal of Earth Science;J. Earth Sci.
 Journal of Earth System Science;J. Earth Syst. Sci.
 Journal of Elasticity;J. Elast.
@@ -633,7 +633,7 @@ Journal of Non-Newtonian Fluid Mechanics;J. Non-Newtonian Fluid Mech.
 Journal of Nondestructive Evaluation;J. Nondestr. Eval.
 Journal of Nonlinear Mathematical Physics;J. Nonlinear Math. Phys.
 Journal of Nonlinear Science;J. Nonlinear Sci.
-Journal of Nuclear Energy, Part C: Plasma Physics, Accelerators, Thermonuclear Research;J. Nucl. Energy, Part C
+Journal of Nuclear Energy, Part C: Plasma Physics, Accelerators, Thermonuclear Research;J. Nucl. Energy C
 Journal of Nuclear Energy;J. Nucl. Energy
 Journal of Nuclear Materials;J. Nucl. Mater.
 Journal of Optics;J. Opt.
@@ -961,7 +961,7 @@ Physical Mesomechanics;Phys. Mesomech.
 Physical Review A: Atomic, Molecular, and Optical Physics;Phys. Rev. A: At. Mol. Opt. Phys.
 Physical Review A;Phys. Rev. A
 Physical Review Accelerators and Beams;Phys. Rev. Accel. Beams
-Physical Review Applied;Phys. Rev. Appl.
+Physical Review Applied;Phys. Rev. Applied
 Physical Review B;Phys. Rev. B
 Physical Review B: Condensed Matter;Phys. Rev. B: Condens. Matter
 Physical Review C;Phys. Rev. C
@@ -973,7 +973,7 @@ Physical Review E: Statistical, Nonlinear, and Soft Matter Physics;Phys. Rev. E:
 Physical Review E: Statistical Physics, Plasmas, Fluids, and Related Interdisciplinary Topics;Phys. Rev. E: Stat. Phys. Plasmas Fluids Relat. Interdisciplin. Top.
 Physical Review Fluids;Phys. Rev. Fluids
 Physical Review Letters;Phys. Rev. Lett.
-Physical Review Materials;Phys. Rev. Mater.
+Physical Review Materials;Phys. Rev. Materials
 Physical Review Physics Education Research;Phys. Rev. Phys. Educ. Res.
 Physical Review Research;Phys. Rev. Research
 Physical Review Special Topics – Accelerators and Beams;Phys. Rev. Spec. Top. Accel. Beams

--- a/journals/journal_abbreviations_lifescience.csv
+++ b/journals/journal_abbreviations_lifescience.csv
@@ -1348,17 +1348,12 @@ BTTA Review;BTTA Rev.
 BZB: Bayerisches Zahnarzteblatt, mit Mitteilungen d. Kassenzahnarztlichen Vereinigung Bayerns;BZB Bayer. Zahnarztebl. Mitt. Kassenzahnarztl. Ver. Bayerns
 Bacteriologia, Virusologia, Parazitologia, Epidemiologia;Bacteriol. Virusol. Parazitol. Epidemiol.
 Bacteriological Reviews;Bacteriol. Rev.
-Bailliere's Best Practice and Research. Clinical Endocrinology and Metabolism;Baillieres Best Pract. Res. Clin. Endocrinol. Metab.
-Bailliere's Best Practice and Research. Clinical Gastroenterology;Baillieres Best Pract. Res. Clin. Gastroenterol.
-Bailliere's Best Practice and Research. Clinical Haematology;Baillieres Best Pract. Res. Clin. Haematol.
-Bailliere's Best Practice and Research. Clinical Obstetrics and Gynaecology;Baillieres Best Pract. Res. Clin. Obstet. Gynaecol.
-Bailliere's Best Practice and Research. Clinical Rheumatology;Baillieres Best Pract. Res. Clin. Rheumatol.
-Bailliere's Clinical Endocrinology and Metabolism;Baillieres Clin. Endocrinol. Metab.
-Bailliere's Clinical Gastroenterology;Baillieres Clin. Gastroenterol.
-Bailliere's Clinical Haematology;Baillieres Clin. Haematol.
-Bailliere's Clinical Neurology;Baillieres Clin. Neurol.
-Bailliere's Clinical Obstetrics and Gynaecology;Baillieres Clin. Obstet. Gynaecol.
-Bailliere's Clinical Rheumatology;Baillieres Clin. Rheumatol.
+Baillière's Clinical Endocrinology and Metabolism;Baillieres Clin. Endocrinol. Metab.
+Baillière's Clinical Gastroenterology;Baillieres Clin. Gastroenterol.
+Baillière's Clinical Haematology;Baillieres Clin. Haematol.
+Baillière's Clinical Neurology;Baillieres Clin. Neurol.
+Baillière's Clinical Obstetrics and Gynaecology;Baillieres Clin. Obstet. Gynaecol.
+Baillière's Clinical Rheumatology;Baillieres Clin. Rheumatol.
 Balance;Balance
 Bangladesh Medical Research Council Bulletin;Bangladesh Med. Res. Counc. Bull.
 Barbados Nursing Journal;Barbados Nurs. J.
@@ -1418,13 +1413,13 @@ Berichte aus der Bonner Universitatsklinik und Poliklinik fur Mund-, Zahn- und K
 Berita Jururawat;Berita Jururawat
 Berliner und Munchener Tierarztliche Wochenschrift;Berl. Munch. Tierarztl. Wochenschr.
 Berufs-Dermatosen;Berufsdermatosen.
-Best Practice and Research. Clinical Anaesthesiology;Best Pract. Res. Clin. Anaesthesiol.
-Best Practice and Research. Clinical Endocrinology and Metabolism;Best Pract. Res. Clin. Endocrinol. Metab.
-Best Practice and Research. Clinical Gastroenterology;Best Pract. Res. Clin. Gastroenterol.
-Best Practice and Research. Clinical Haematology;Best Pract. Res. Clin. Haematol.
-Best Practice and Research. Clinical Obstetrics and Gynaecology;Best Pract. Res. Clin. Obstet. Gynaecol.
-Best Practice and Research. Clinical Rheumatology;Best Pract. Res. Clin. Rheumatol.
-Best Practices and Benchmarking in Healthcare;Best Pract. Benchmarking Healthc.
+Best Practice & Research: Clinical Anaesthesiology;Best Pract. Res. Clin. Anaesthesiol.
+Best Practice & Research: Clinical Endocrinology and Metabolism;Best Pract. Res. Clin. Endocrinol. Metab.
+Best Practice & Research: Clinical Gastroenterology;Best Pract. Res. Clin. Gastroenterol.
+Best Practice & Research: Clinical Haematology;Best Pract. Res. Clin. Haematol.
+Best Practice & Research: Clinical Obstetrics and Gynaecology;Best Pract. Res. Clin. Obstet. Gynaecol.
+Best Practice & Research: Clinical Rheumatology;Best Pract. Res. Clin. Rheumatol.
+Best Practices & Benchmarking in Healthcare;Best Pract. Benchmarking Healthc.
 Best's Review. Life/Health Insurance Edition;Bests Rev. Life. Health Insur. Ed.
 Bibliotek for Laeger;Bibl. Laeger
 Bibliotheca Anatomica;Bibl. Anat.

--- a/journals/journal_abbreviations_lifescience.csv
+++ b/journals/journal_abbreviations_lifescience.csv
@@ -196,7 +196,7 @@ Acta Microbiologica et Immunologica Hungarica;Acta Microbiol. Immunol. Hung.
 Acta Microbiologica, Virologica et Immunologica;Acta Microbiol. Virol. Immunol. (Sofiia)
 Acta Morphologica Academiae Scientiarum Hungaricae;Acta Morphol. Acad. Sci. Hung.
 Acta Morphologica Hungarica;Acta Morphol. Hung.
-Acta Morphologica Neerlando-Scandinavica;Acta Morphol. Neerl. Scand.
+Acta Morphologica Neerlando-Scandinavica;Acta Morphol. Neerl.-Scand.
 Acta Médica Costarricense;Acta méd. costarric.
 Acta Neurobiologiae Experimentalis;Acta Neurobiol. Exp. (Warsz.)
 Acta Neurochirurgica;Acta Neurochir. (Wien)
@@ -512,8 +512,8 @@ Albrecht von Graefes Archiv fur Klinische und Experimentelle Ophthalmologie;Albr
 Alcohol;Alcohol
 Alcohol Health and Research World;Alcohol Health Res. World
 Alcohol Research and Health;Alcohol Res. Health
-Alcohol and Alcoholism;Alcohol Alcohol
-Alcohol and Alcoholism. Supplement;Alcohol Alcohol Suppl.
+Alcohol and Alcoholism;Alcohol Alcohol.
+Alcohol and Alcoholism. Supplement;Alcohol Alcohol. Suppl.
 Alcohol and Drug Research;Alcohol Drug Res.
 Alcoholism, Clinical and Experimental Research;Alcohol. Clin. Exp. Res.
 Alergia;Alergia
@@ -951,9 +951,9 @@ Annual Review of Rehabilitation;Annu. Rev. Rehabil.
 Annual Review of Sex Research;Annu. Rev. Sex Res.
 Annual Symposium on Nursing Faculty Practice;Annu. Symp. Nurs. Fac. Pract.
 Anthropologischer Anzeiger;Anthropol. Anz.
-Anti-Cancer Agents in Medicinal Chemistry;Anticancer Agents Med. Chem.
-Anti-Cancer Drug Design;Anticancer. Drug Des.
-Anti-Cancer Drugs;Anticancer. Drugs
+Anti-Cancer Agents in Medicinal Chemistry;Anti-Cancer Agents Med. Chem.
+Anti-Cancer Drug Design;Anti-Cancer Drug Des.
+Anti-Cancer Drugs;Anti-Cancer Drugs
 Antibiotica;Antibiotica
 Antibiotica. Quaderni;Antibiotica. [Quad.]
 Antibiotics and Chemotherapy;Antibiot. Chemother.
@@ -1007,28 +1007,28 @@ Architecture;Architecture
 Archiv der Julius Klaus-Stiftung fur Vererbungsforschung, Sozialanthropologie und Rassenhygiene;Arch. Julius Klaus Stift. Vererbungsforsch. Sozialanthropol. Rassenhyg.
 Archiv der Pharmazie;Arch. Pharm. (Weinheim)
 Archiv der Pharmazie und Berichte der Deutschen Pharmazeutischen Gesellschaft;Arch. Pharm. Ber. Dtsch. Pharm. Ges.
-Archiv fur Dermatologische Forschung;Arch. Dermatol. Forsch.
-Archiv fur Experimentelle Veterinarmedizin;Arch. Exp. Veterinarmed.
-Archiv fur Genetik;Arch. Genet. (Zur.)
-Archiv fur Geschwulstforschung;Arch. Geschwulstforsch.
-Archiv fur Gynakologie;Arch. Gynakol.
-Archiv fur Hygiene und Bakteriologie;Arch. Hyg. Bakteriol.
-Archiv fur Kinderheilkunde;Arch. Kinderheilkd.
-Archiv fur Klinische Medizin;Arch. Klin. Med.
-Archiv fur Klinische und Experimentelle Dermatologie;Arch. Klin. Exp. Dermatol.
-Archiv fur Klinische und Experimentelle Ohren-, Nasen- und Kehlkopfheilkunde;Arch. Klin. Exp. Ohren. Nasen. Kehlkopfheilkd.
-Archiv fur Kreislaufforschung;Arch. Kreislaufforsch.
-Archiv fur Kriminologie;Arch. Kriminol.
-Archiv fur Mikrobiologie;Arch. Mikrobiol.
-Archiv fur Ohren-, Nasen- und Kehlkopfheilkunde;Arch. Ohren Nasen Kehlkopfheilkd.
-Archiv fur Orthopadische und Unfall-Chirurgie;Arch. Orthop. Unfallchir.
-Archiv fur Physikalische Therapie;Arch. Phys. Ther. (Leipz.)
-Archiv fur Psychiatrie und Nervenkrankheiten;Arch. Psychiatr. Nervenkr.
-Archiv fur Psychologie;Arch. Psychol. (Frankf.)
-Archiv fur Tierernahrung;Arch. Tierernahr.
-Archiv fur Toxikologie;Arch. Toxikol.
-Archiv fur die Gesamte Psychologie;Arch. Gesamte Psychol.
-Archiv fur die Gesamte Virusforschung;Arch. Gesamte Virusforsch.
+Archiv für Dermatologische Forschung;Arch. Dermatol. Forsch.
+Archiv für Experimentelle Veterinarmedizin;Arch. Exp. Veterinarmed.
+Archiv für Genetik;Arch. Genet. (Zur.)
+Archiv für Geschwulstforschung;Arch. Geschwulstforsch.
+Archiv für Gynakologie;Arch. Gynakol.
+Archiv für Hygiene und Bakteriologie;Arch. Hyg. Bakteriol.
+Archiv für Kinderheilkunde;Arch. Kinderheilkd.
+Archiv für Klinische Medizin;Arch. Klin. Med.
+Archiv für Klinische und Experimentelle Dermatologie;Arch. Klin. Exp. Dermatol.
+Archiv für Klinische und Experimentelle Ohren-, Nasen- und Kehlkopfheilkunde;Arch. Klin. Exp. Ohren. Nasen. Kehlkopfheilkd.
+Archiv für Kreislaufforschung;Arch. Kreislaufforsch.
+Archiv für Kriminologie;Arch. Kriminol.
+Archiv für Mikrobiologie;Arch. Mikrobiol.
+Archiv für Ohren-, Nasen- und Kehlkopfheilkunde;Arch. Ohren Nasen Kehlkopfheilkd.
+Archiv für Orthopadische und Unfall-Chirurgie;Arch. Orthop. Unfallchir.
+Archiv für Physikalische Therapie;Arch. Phys. Ther. (Leipz.)
+Archiv für Psychiatrie und Nervenkrankheiten;Arch. Psychiatr. Nervenkr.
+Archiv für Psychologie;Arch. Psychol. (Frankf.)
+Archiv für Tierernahrung;Arch. Tierernahr.
+Archiv für Toxikologie;Arch. Toxikol.
+Archiv für die Gesamte Psychologie;Arch. Gesamte Psychol.
+Archiv für die Gesamte Virusforschung;Arch. Gesamte Virusforsch.
 Archives Belges;Arch. Belg.
 Archives Belges de Dermatologie;Arch. Belg. Dermatol.
 Archives Belges de Dermatologie et de Syphiligraphie;Arch. Belg. Dermatol. Syphiligr.
@@ -1489,7 +1489,7 @@ Biologica;Biologica (Santiago).
 Biologica Latina;Biol. Lat.
 Biological Bulletin;Biol. Bull.
 Biological Chemistry;Biol. Chem.
-Biological Chemistry Hoppe-Seyler;Biol. Chem. Hoppe. Seyler
+Biological Chemistry Hoppe-Seyler;Biol. Chem. Hoppe-Seyler
 Biological Cybernetics;Biol. Cybern.
 Biological Journal of the Linnean Society of London;Biol. J. Linn. Soc. Lond.
 Biological Mass Spectrometry;Biol. Mass Spectrom.
@@ -3013,7 +3013,7 @@ Drug Information Journal;Drug Inf. J.
 Drug Intelligence and Clinical Pharmacy;Drug Intell. Clin. Pharm.
 Drug Metabolism Reviews;Drug Metab. Rev.
 Drug Metabolism and Disposition;Drug Metab. Dispos.
-Drug Metabolism and Drug Interactions;Drug Metabol. Drug Interact.
+Drug Metabolism and Drug Interactions;Drug Metab. Drug Interact.
 Drug Metabolism and Pharmacokinetics;Drug Metab. Pharmacokinet.
 Drug Resistance Updates;Drug Resist. Updat.
 Drug Safety;Drug Saf.
@@ -3143,7 +3143,7 @@ Engineering in Medicine;Eng. Med.
 Entomologia y Vectores;Entomol. Vect.
 Entomological News;Entomol. News
 Environmental Biology and Medicine;Environ. Biol. Med.
-Environmental Biosafety Research;Environ. Biosafety Res.
+Environmental Biosafety Research;Environ. Biosaf. Res.
 Environmental Health;Environ. Health
 Environmental Health Perspectives;Environ. Health Perspect.
 Environmental Health Series. Radiological Health;Environ. Health Ser. [Radiol. Health]
@@ -4390,7 +4390,7 @@ International Journal of Injury Control and Safety Promotion;Int. J. Inj. Contr.
 International Journal of Instructional Media;Int. J. Instr. Media
 International Journal of Language and Communication Disorders;Int. J. Lang. Commun. Disord.
 International Journal of Law and Psychiatry;Int. J. Law Psychiatry
-International Journal of Legal Medicine;Int. J. Legal Med.
+International Journal of Legal Medicine;Int. J. Leg. Med.
 International Journal of Leprosy;Int. J. Lepr.
 International Journal of Leprosy and Other Mycobacterial Diseases;Int. J. Lepr. Other Mycobact. Dis.
 International Journal of Lower Extremity Wounds;Int. J. Low. Extrem. Wounds
@@ -4518,7 +4518,7 @@ Irish Nursing News;Ir. Nurs. News
 Irish Nursing and Hospital World;Ir. Nurs. Hosp. World
 Iryo;Iryo
 Isis;Isis
-Isotopes in Environmental and Health Studies;Isotopes Environ. Health Stud.
+Isotopes in Environmental and Health Studies;Isot. Environ. Health Stud.
 "Isozymes; Current Topics in Biological Medical Research";Isozymes Curr. Top. Biol. Med. Res.
 Israel Annals of Psychiatry and Related Disciplines;Isr. Ann. Psychiatr. Relat. Discip.
 Israel Journal of Dental Medicine;Isr. J. Dent. Med.
@@ -4741,7 +4741,7 @@ Journal of Behavioral Medicine;J. Behav. Med.
 Journal of Biochemical Toxicology;J. Biochem. Toxicol.
 Journal of Biochemical and Biophysical Methods;J. Biochem. Biophys. Methods
 Journal of Biochemical and Molecular Toxicology;J. Biochem. Mol. Toxicol.
-Journal of Biochemistry;J. Biochem. (Tokyo)
+Journal of Biochemistry;J. Biochem.
 Journal of Biochemistry, Molecular Biology, and Biophysics;J. Biochem. Mol. Biol. Biophys.
 Journal of Biocommunication;J. Biocommun.
 Journal of Bioenergetics;J. Bioenerg.
@@ -4909,7 +4909,7 @@ Journal of Compliance in Health Care;J. Compliance Health Care
 Journal of Computational Biology;J. Comput. Biol.
 Journal of Computational Neuroscience;J. Comput. Neurosci.
 Journal of Computed Tomography;J. Comput. Tomogr.
-Journal of Computer Assisted Tomography;J. Comput. Assist. Tomogr.
+Journal of Computer Assisted Tomography;J. Comput. Assisted Tomogr.
 Journal of Computer-Aided Molecular Design;J. Comput. Aided Mol. Des.
 Journal of Consulting Psychology;J. Consult. Psychol.
 Journal of Consulting and Clinical Psychology;J. Consult. Clin. Psychol.
@@ -4971,7 +4971,7 @@ Journal of Economics and Business;J. Econ. Bus.
 Journal of Educational Psychology;J. Educ. Psychol.
 Journal of Electrocardiology;J. Electrocardiol.
 Journal of Electromyography and Kinesiology;J. Electromyogr. Kinesiol.
-Journal of Electron Microscopy;J. Electron Microsc. (Tokyo)
+Journal of Electron Microscopy;J. Electron Microsc.
 Journal of Electron Microscopy Technique;J. Electron Microsc. Tech.
 Journal of Embryology and Experimental Morphology;J. Embryol. Exp. Morphol.
 Journal of Emergency Medical Services;J. Emerg. Med. Serv. JEMS
@@ -4993,7 +4993,7 @@ Journal of Environmental Science and Engineering;J. Environ. Sci. Eng.
 Journal of Environmental Science and Health. Part A, Toxic/Hazardous Substances and Environmental Engineering;J. Environ. Sci. Health Part A Tox. Hazard. Subst. Environ. Eng.
 Journal of Environmental Science and Health. Part B, Pesticides, Food Contaminants, and Agricultural Wastes;J. Environ. Sci. Health B
 Journal of Environmental Science and Health. Part C, Environmental Health Sciences;J. Environ. Sci. Health [C]
-Journal of Enzyme Inhibition;J. Enzym. Inhib.
+Journal of Enzyme Inhibition;J. Enzyme Inhib.
 Journal of Enzyme Inhibition and Medicinal Chemistry;J. Enzyme Inhib. Med. Chem.
 Journal of Epidemiology;J. Epidemiol.
 Journal of Epidemiology and Biostatistics;J. Epidemiol. Biostat.
@@ -5335,7 +5335,7 @@ Journal of Nutrition;J. Nutr.
 Journal of Nutrition Education and Behavior;J. Nutr. Educ. Behav.
 Journal of Nutrition for the Elderly;J. Nutr. Elder.
 Journal of Nutrition, Health and Aging;J. Nutr. Health Aging
-Journal of Nutritional Science and Vitaminology;J. Nutr. Sci. Vitaminol. (Tokyo)
+Journal of Nutritional Science and Vitaminology;J. Nutr. Sci. Vitaminol.
 Journal of Obstetric, Gynecologic, and Neonatal Nursing;J. Obstet. Gynecol. Neonatal Nurs.
 Journal of Obstetrics and Gynaecology;J. Obstet. Gynaecol.
 Journal of Obstetrics and Gynaecology Canada;J. Obstet. Gynaecol. Can.
@@ -5417,7 +5417,7 @@ Journal of Pharmaceutical Marketing and Management;J. Pharm. Mark. Manage.
 Journal of Pharmaceutical Science and Technology;J. Pharm. Sci. Technol.
 Journal of Pharmaceutical Sciences;J. Pharm. Sci.
 Journal of Pharmaceutical and Biomedical Analysis;J. Pharm. Biomed. Anal.
-Journal of Pharmacobio-Dynamics;J. Pharmacobiodyn.
+Journal of Pharmacobio-Dynamics;J. Pharmacobio-Dyn.
 Journal of Pharmacokinetics and Biopharmaceutics;J. Pharmacokinet. Biopharm.
 Journal of Pharmacokinetics and Pharmacodynamics;J. Pharmacokinet. Pharmacodyn.
 Journal of Pharmacological Methods;J. Pharmacol. Methods
@@ -5464,7 +5464,7 @@ Journal of Psychiatric Nursing and Mental Health Services;J. Psychiatr. Nurs.
 Journal of Psychiatric Research;J. Psychiatr. Res.
 Journal of Psychiatric and Mental Health Nursing;J. Psychiatr. Ment. Health Nurs.
 Journal of Psychiatry and Neuroscience;J. Psychiatry Neurosci.
-Journal of Psychoactive Drugs;J. Psychoactive Drugs
+Journal of Psychoactive Drugs;J. Psychoact. Drugs
 Journal of Psycholinguistic Research;J. Psycholinguist. Res.
 Journal of Psychology;J. Psychol.
 Journal of Psychopharmacology;J. Psychopharmacol. (Oxf.)
@@ -5967,7 +5967,7 @@ LA Reports;LA Rep.
 LARC Medical;LARC Med.
 LDA Journal;LDA J.
 "LMT; Lab Management Today";LMT
-Lab on a Chip;Lab. Chip
+Lab on a Chip;Lab Chip
 Labor Law Journal;Labor Law J.
 Laboratorio;Laboratorio
 Laboratornoe Delo;Lab. Delo
@@ -6525,7 +6525,7 @@ Molecular Pathology;Mol. Pathol.
 Molecular Pharmaceutics;Mol. Pharm.
 Molecular Pharmacology;Mol. Pharmacol.
 Molecular Phylogenetics and Evolution;Mol. Phylogenet. Evol.
-Molecular Plant-Microbe Interactions;Mol. Plant. Microbe Interact.
+Molecular Plant-Microbe Interactions;Mol. Plant-Microbe Interact.
 Molecular Psychiatry;Mol. Psychiatry
 Molecular Reproduction and Development;Mol. Reprod. Dev.
 Molecular Systems Biology;Mol. Syst. Biol.
@@ -6713,9 +6713,9 @@ Nature. New Biology;Nature. New Biol.
 Naturwissenschaften;Naturwissenschaften
 Nauchni Trudove na Nauchno-Izsledovatelskiia Stomatologichen Institut;Nauchni Tr. Nauchnoizsled. Stomatol. Inst. (Sofiia)
 Nauchni Trudove na Visshiia Meditsinski Institut, Sofiia;Nauchni Tr. Vissh. Med. Inst. Sofiia
-Naunyn-Schmiedeberg's Archives of Pharmacology;Naunyn. Schmiedebergs Arch. Pharmacol.
-Naunyn-Schmiedebergs Archiv fur Experimentelle Pathologie und Pharmakologie;Naunyn. Schmiedebergs Arch. Exp. Pathol. Pharmakol.
-Naunyn-Schmiedebergs Archiv fur Pharmakologie;Naunyn. Schmiedebergs Arch. Pharmakol.
+Naunyn-Schmiedeberg's Archives of Pharmacology;Naunyn-Schmiedeberg's Arch. Pharmacol.
+Naunyn-Schmiedebergs Archiv für Experimentelle Pathologie und Pharmakologie;Naunyn. Schmiedebergs Arch. Exp. Pathol. Pharmakol.
+Naunyn-Schmiedebergs Archiv für Pharmakologie;Naunyn. Schmiedebergs Arch. Pharmakol.
 Navy Medicine;Navy Med.
 Nebraska Medical Journal;Nebr. Med. J.
 Nebraska Nurse;Nebr. Nurse
@@ -8138,7 +8138,7 @@ Reviews of Infectious Diseases;Rev. Infect. Dis.
 Reviews of Oculomotor Research;Rev. Oculomot. Res.
 Reviews of Physiology, Biochemistry and Pharmacology;Rev. Physiol. Biochem. Pharmacol.
 Reviews of Reproduction;Rev. Reprod.
-Reviews on Drug Metabolism and Drug Interactions;Rev. Drug Metabol. Drug Interact.
+Reviews on Drug Metabolism and Drug Interactions;Rev. Drug Metab. Drug Interact.
 Reviews on Environmental Health;Rev. Environ. Health
 Revisiones sobre Biologia Celular;Revis. Biol. Celular
 Revista ADM;Rev. ADM

--- a/journals/journal_abbreviations_mathematics.csv
+++ b/journals/journal_abbreviations_mathematics.csv
@@ -716,7 +716,7 @@ Computational Statistics & Data Analysis;Comput. Statist. Data Anal.
 Computational and Experimental Methods in Structures;Comput. Exp. Methods Struct.
 Computational and Mathematical Biophysics;Comput. Math. Biophys.
 Computational and Mathematical Methods in Medicine;Comput. Math. Methods Med.
-Computer Aided Geometric Design;Comput. Aided Geom. Design
+Computer Aided Geometric Design;Comput. Aided Geom. Des.
 Computer Communications and Networks;Comput. Commun. Netw.
 Computer Engineering Series;Comput. Eng. Ser.
 Computer Life;Comput. Life
@@ -987,7 +987,7 @@ European Journal of Control;Eur. J. Control
 European Journal of Mathematics;Eur. J. Math.
 European Journal of Mechanics. A. Solids;Eur. J. Mech. A Solids
 European Journal of Mechanics. B. Fluids;Eur. J. Mech. B Fluids
-European Journal of Operational Research;European J. Oper. Res.
+European Journal of Operational Research;Eur. J. Oper. Res.
 European Journal of Pure and Applied Mathematics;Eur. J. Pure Appl. Math.
 European Mathematical Society. Newsletter;Eur. Math. Soc. Newsl.
 European Studies in Philosophy of Science;Eur. Stud. Philos. Sci.
@@ -1298,7 +1298,7 @@ International Journal for Numerical Methods in Biomedical Engineering;Int. J. Nu
 International Journal for Numerical Methods in Engineering;Internat. J. Numer. Methods Engrg.
 International Journal for Numerical Methods in Fluids;Internat. J. Numer. Methods Fluids
 International Journal for Uncertainty Quantification;Int. J. Uncertain. Quantif.
-International Journal of Adaptive Control and Signal Processing;Internat. J. Adapt. Control Signal Process.
+International Journal of Adaptive Control and Signal Processing;Int. J. Adapt. Control Signal Process.
 International Journal of Advances in Applied Mathematics and Mechanics;Int. J. Adv. Appl. Math. Mech.
 International Journal of Advances in Engineering Sciences and Applied Mathematics;Int. J. Adv. Eng. Sci. Appl. Math.
 International Journal of Algebra and Computation;Internat. J. Algebra Comput.

--- a/journals/journal_abbreviations_mechanical.csv
+++ b/journals/journal_abbreviations_mechanical.csv
@@ -382,7 +382,7 @@ Astronomical Journal;Astron. J.
 Astronomische Nachrichten;Astron. Nachr.
 Astronomy & Geophysics;Astron. Geophys.
 Astronomy Education Review;Astron. Educ. Rev.
-Astronomy Journal;Astron. J.
+Astronomical Journal;Astron. J.
 Astronomy Letters;Astron. Lett.
 Astronomy Reports;Astron. Rep.
 Astronomy and Astrophysics;Astron. Astrophys.
@@ -3773,14 +3773,14 @@ Osterreichische Chemie Zeitschrift;Osterr. Chem. Z.
 Oxidation of Metals;Oxid. Met.
 Ozone Science and Engineering;Ozone Sci. Eng.
 PDA Journal of Pharmaceutical Science and Technology;PDA J. Pharm. Sci. Technol.
-PLoS Biology;PLoS Biol.
-PLoS Clinical Trials;PLoS Clin. Trials
-PLoS Computational Biology;PLoS Comput. Biol.
-PLoS Genetics;PLoS Genet.
-PLoS Medicine;PLoS Med.
-PLoS Neglected Tropical Diseases;PLoS Negl.Trop. Dis.
-PLoS One;PLoS One
-PLoS Pathogens;PLoS Pathog.
+PLOS Biology;PLOS Biol.
+PLOS Clinical Trials;PLOS Clin. Trials
+PLOS Computational Biology;PLOS Comput. Biol.
+PLOS Genetics;PLOS Genet.
+PLOS Medicine;PLOS Med.
+PLOS Neglected Tropical Diseases;PLOS Negl.Trop. Dis.
+PLOS One;PLoS One
+PLOS Pathogens;PLoS Pathog.
 PMC Physics A;PMC Phys. A
 PMC Physics B;PMC Phys. B
 PMSE Preprints;PMSE Prepr.

--- a/journals/journal_abbreviations_mechanical.csv
+++ b/journals/journal_abbreviations_mechanical.csv
@@ -11,7 +11,7 @@ ACS Symposium Series;ACS Symp. Ser.
 AEU International Journal of Electronics and Communications;AEU Int. J. Electron. Commun.
 AGSO Journal of Australian Geology and Geophysics;AGSO J. Aust. Geol. Geophys.
 AIChE Journal;AlChE J.
-AIChE Symposium Series;AlChE Symp. Ser.
+AIChE Symposium Series;AIChE Symp. Ser.
 AQEIC Boletin Tecnico;AQEIC Bol. Tec.
 ASTM Specical Technical Publication;ASTM Spec. Tech. Publ.
 Abhandlungen der Senckenbergischen Naturforschenden Gesellschaft;Abh. Senckb. Naturforsch. Ges.
@@ -27,7 +27,7 @@ Acta Agriculturae Scandinavica Section B: Soil and Plant Science;Acta Agric. Sca
 Acta Astronautica;Acta Astronaut.
 Acta Automatica Sinica;Acta Autom. Sin.
 Acta Biochimica Polonica;Acta Biochim. Pol.
-Acta Biochimica et Biophysica Sinica;Acta Biochim. Biophy. Sin.
+Acta Biochimica et Biophysica Sinica;Acta Biochim. Biophys. Sin.
 Acta Biologica et Medica Germanica;Acta Biol. Med. Ger.
 Acta Biomaterialia;Acta Biomater.
 Acta Bioquimica Clinica Latinoamericana;Acta Bioquim. Clin. Latinoam.
@@ -60,7 +60,7 @@ Acta Mechanica Solida Sinica;Acta Mech. Solida Sin.
 Acta Metallurgica;Acta Metall.
 Acta Metallurgica Sinica;Acta Metall. Sinica
 Acta Metallurgica et Materialia;Acta Metall. Mater.
-Acta Neuropathologica;Acta Neuropathol.
+Acta Neuropathologica;Acta Neuropathol. (Berl.)
 Acta Oceanologica Sinica;Acta Oceanolog. Sin.
 Acta Odontologica Scandinavica;Acta Odontol. Scand.
 Acta Pharmacologica Sinica;Acta Pharmacol. Sin.
@@ -217,7 +217,7 @@ Annalen der Physik;Ann. Phys.
 Annales Geophysicae;Ann. Geophys.
 Annales Hydrographiques;Ann. Hydrogr.
 Annales de Biochimie Clinque du Quebec;Ann. Biochim. Clin. Que.
-Annales de Biologie Clinique;Ann. Biol. Clin.
+Annales de Biologie Clinique;Ann. Biol. Clin. (Paris)
 Annales de Biologie Clinique du Quebec;Ann. Biol. Clin. Que.
 Annales de Chimie;Ann. Chim.
 Annales de Chimie Analytique et Revue de Chimie Analytique Reunies;Ann. Chim. Anal. Rev. Chim. Anal. Reunies
@@ -285,7 +285,7 @@ Applied Geochemistry;Appl. Geochem.
 Applied Geography;Appl. Geogr.
 Applied Geophysics;Appl. Geophys.
 Applied Magnetic Resonance;Appl. Magn. Reson.
-Applied Mathematical Modelling;Appl. Math. Modell.
+Applied Mathematical Modelling;Appl. Math. Model.
 Applied Mathematics Letters;Appl. Math. Lett.
 Applied Mathematics and Computation;Appl. Math. Comput.
 Applied Mathematics and Optimization;Appl. Math. Optim.
@@ -322,21 +322,21 @@ Arabian Journal of Chemistry;Arabian J. Chem.
 Arabian Journal of Geosciences;Arabian J. Geosci.
 Arbeiten der DLG;Arb. DLG
 Arbeiten der Kaiserlichen Biologischen Anstalt fur Land- und Forstwirtschaft;Arb. Kais. Biol. Anst. Land Forstwirtsch.
-Archiv der Pharmazie;Arch. Pharm.
-Archiv fur Elektrotechnik;Arch. Elektrotech.
-Archiv fur Experimentalle Pathologie und Pharmakologie;Arch. Exp. Pathol. Pharmakol.
-Archiv fur Hydrobiologie, Supplement;Arch. Hydrobiol. Suppl.
-Archiv fur Kriminologie;Arch. Krim.
-Archiv fur Lagerstattenforschung;Arch. Lagerstattenforsch.
-Archiv fur Lebensmittelhygiene;Arch. Lebensmittelhyg.
-Archiv fur Meteorologie, Geophysik, und Bioklimatologie Serie A Meteorologie und Geophysik;Arch. Meteorol. Geophys. Bioklimatol. A
+Archiv der Pharmazie;Arch. Pharm. (Weinheim)
+Archiv für Elektrotechnik;Arch. Elektrotech.
+Archiv für Experimentalle Pathologie und Pharmakologie;Arch. Exp. Pathol. Pharmakol.
+Archiv für Hydrobiologie, Supplement;Arch. Hydrobiol. Suppl.
+Archiv für Kriminologie;Arch. Kriminol.
+Archiv für Lagerstattenforschung;Arch. Lagerstattenforsch.
+Archiv für Lebensmittelhygiene;Arch. Lebensmittelhyg.
+Archiv für Meteorologie, Geophysik, und Bioklimatologie Serie A Meteorologie und Geophysik;Arch. Meteorol. Geophys. Bioklimatol. A
 Archive for History of Exact Sciences;Arch. Hist. Exact Sci.
 Archive for Rational Mechanics and Analysis;Arch. Ration. Mech. Anal.
-Archives Neerlandaises Sci Exactes et Naturelles;Arch. Neerl. Sci. Exactes Nat.
+Archives Neerlandaises des Sciences Exactes et Naturelles;Arch. Neerl. Sci. Exactes Nat.
 Archives des Maladies Professionnelles et de l'Environment;Arch. Mal. Prof. Environ.
 Archives of Agronomy and Soil Science;Arch. Agron. Soil Sci.
 Archives of Biochemistry and Biophysics;Arch. Biochem. Biophys.
-Archives of Computational Methods in Engineering;Arch. Comput. Meth. Eng.
+Archives of Computational Methods in Engineering;Arch. Comput. Methods Eng.
 Archives of Environment Contamination and Toxicology;Arch. Environ. Contam. Toxicol.
 Archives of Environment Health;Arch. Environ. Health
 Archives of Environmental & Occupational Health;Arch. Environ. Occup. Health
@@ -404,7 +404,7 @@ Atmospheric Research Letters;Atmos. Res. Lett.
 Atmospheric Science Letters;Atmos. Sci. Lett.
 Atmospheric and Oceanic Optics;Atmos. Oceanic Opt.
 Atomic Data and Nuclear Data Tables;At. Data Nucl. Data Tables
-Atomic Energy;At. Energ.
+Atomic Energy;At. Energy
 Atomic Spectroscopy;At. Spectrosc.
 Atomization and Sprays;Atomization Sprays
 Atti della Accademia Nazionale dei Lincei, Classe di Scienze Fisiche, Matematiche e Naturali, Rendiconti;Atti Accad. Naz. Lincei Cl. Sci. Fis. Mat. Nat. Rend.
@@ -429,19 +429,19 @@ BHM Berg- und Huttenmannische Monatshefte;BHM Berg- Huttenmann. Monatsh.
 BMC Biochemistry;BMC Biochem.
 BMC Bioinformatics;BMC Bioinf.
 BMC Biology;BMC Biol.
-BMC Biotechnology;BMC Biotech.
-BMC Chemical Biology;BMC Chem. Biol
+BMC Biotechnology;BMC Biotechnol.
+BMC Chemical Biology;BMC Chem. Biol.
 BMC Clinical Pharmacology;BMC Clin. Pharmacol.
-BMC Developmental Biology;BMC Dev. Biol
+BMC Developmental Biology;BMC Dev. Biol.
 BMC Ecology;BMC Ecol.
 BMC Evolutionary Biology;BMC Evol. Biol.
 BMC Genetics;BMC Genet.
 BMC Medical Genetics;BMC Med. Genet.
-BMC Medical Genomics;BMC Med. Genet.
+BMC Medical Genomics;BMC Med. Genomics
 BMC Medical Imaging;BMC Med. Imaging
-BMC Medical Informatics and Decision Making;BMC Med. Inf. Decis. Making
+BMC Medical Informatics and Decision Making;BMC Med. Inform. Decis. Making
 BMC Medical Physics;BMC Med. Phys.
-BMC Medical Research Methodology;BMC Med. Res. Method.
+BMC Medical Research Methodology;BMC Med. Res. Methodol.
 BMC Microbiology;BMC Microbiol.
 BMC Molecular Biology;BMC Mol. Biol.
 BMC Pharmacology;BMC Pharmacol.
@@ -451,7 +451,7 @@ BMC Systems Biology;BMC Syst. Biol.
 BMR Journal of Geology and Geophysics;BMR J. Aust. Geol. Geophys.
 Basic and Applied Ecology;Basic Appl. Ecol.
 Basin Research;Basin Res.
-Bayer CropScience Journal;Bayer CropSci J.
+Bayer CropScience Journal;Bayer CropSci. J.
 Behavioral Ecology and Sociobiology;Behav. Ecol. Sociobiol.
 Behavioural Pharmacology;Behav. Pharmacol.
 Beilstein Journal of Organic Chemistry;Beilstein J. Org. Chem.
@@ -531,7 +531,7 @@ Biological Control;Biol. Control
 Biological Cybernetics;Biol. Cybern.
 Biological Engineering;Biol. Eng.
 Biological Journal of the Linnean Society;Biol. J. Linn. Soc.
-Biological Mass Spectrometry;Biol. Mass. Spectrom.
+Biological Mass Spectrometry;Biol. Mass Spectrom.
 Biological Membranes;Biol. Membr.
 Biological Trace Element Research;Biol. Trace Elem. Res.
 Biological and Medical Physics, Biomedical Engineering;Biol. Med. Phys. Biomed. Eng.
@@ -548,7 +548,7 @@ Biomedical Chromatography;Biomed. Chromatogr.
 Biomedical Imaging and Intervention Journal;Biomed. Imaging Intervention J.
 Biomedical Materials;Biomed. Mater.
 Biomedical Microdevices;Biomed. Microdevices
-Biomedical Research on Trace Elements;Biomed. Res. Trace Ele.
+Biomedical Research on Trace Elements;Biomed. Res. Trace Elem.
 Biomedical Sciences Instrumentation;Biomed. Sci. Instrum.
 Biomedical Signal Processing and Control;Biomed. Signal Process. Control
 Biomedical and Environmental Sciences;Biomed. Environ. Sci.
@@ -568,7 +568,7 @@ Biophysical Reviews and Letters;Biophys. Rev. Lett.
 Biopreservation and Biobanking;Biopreserv. Biobanking
 Bioprocess Engineering;Bioprocess. Eng.
 Bioprocess International;Bioprocess Int.
-Bioprocess and Biosystems Engineering;Bioprocess. Biosyst. Eng.
+Bioprocess and Biosystems Engineering;Bioprocess Biosyst. Eng.
 Bioprocessing Journal;Bioprocess. J.
 Bioremediation Journal;Biorem. J.
 Bioresource Technology;Bioresour. Technol.
@@ -583,7 +583,7 @@ Biotechnologie, Agronomie, Societe et Environnement;Biotechnol. Agron. Soc. Envi
 Biotechnology Advances;Biotechnol. Adv.
 Biotechnology Journal;Biotechnol. J.
 Biotechnology Letters;Biotechnol. Lett
-Biotechnology Progress;Biotechnol. Progr.
+Biotechnology Progress;Biotechnol. Prog.
 Biotechnology Techniques;Biotechnol. Tech.
 Biotechnology and Applied Biochemistry;Biotechnol. Appl. Biochem.
 Biotechnology and Bioengineering;Biotechnol. Bioeng.
@@ -637,7 +637,7 @@ Bulletin de la Classe des Sciences, Academie Royale de Belgique;Bull. Cl. Sci. A
 Bulletin de la Societe Chimique de France;Bull. Soc. Chim. Fr.
 Bulletin de la Societe Francaise de Physique;Bull. Soc. Fr. Phys.
 Bulletin de la Societe Geologique de France;Bull. Soc. Geol. Fr.
-Bulletin de la Societe de Pathologie Exotique;Bull. Soc Pathol. Exot.
+Bulletin de la Societe de Pathologie Exotique;Bull. Soc. Pathol. Exot.
 Bulletin des Societes Chimiques Belges;Bull. Soc. Chim. Belg.
 Bulletin for the History of Chemistry;Bull. Hist. Chem.
 Bulletin of Canadian Petroleum Geology;Bull. Can. Petrol. Geol.
@@ -689,7 +689,7 @@ Canadian Journal of Chemical Engineering;Can. J. Chem. Eng.
 Canadian Journal of Chemistry;Can. J. Chem.
 Canadian Journal of Civil Engineering;Can. J. Civ. Eng.
 Canadian Journal of Earth Sciences;Can. J. Earth Sci.
-Canadian Journal of Fisheries and Aquatic Sciences;Can. J. Fish. Aquat.Sci.
+Canadian Journal of Fisheries and Aquatic Sciences;Can. J. Fish. Aquat. Sci.
 Canadian Journal of Forest Research;Can. J. For. Res.
 Canadian Journal of Genetics and Cytology;Can. J. Genet. Cytol.
 Canadian Journal of Mathematics;Can. J. Math.
@@ -697,8 +697,8 @@ Canadian Journal of Microbiology;Can. J. Microbiol.
 Canadian Journal of Pharmaceutical Sciences;Can. J. Pharm. Sci.
 Canadian Journal of Physics;Can. J. Phys.
 Canadian Journal of Physiology and Pharmacology;Can. J. Physiol. Pharmacol.
-Canadian Journal of Plant Pathology;Can. J. Plant. Pathol.
-Canadian Journal of Plant Science;Can. J. Plant. Sci.
+Canadian Journal of Plant Pathology;Can. J. Plant Pathol.
+Canadian Journal of Plant Science;Can. J. Plant Sci.
 Canadian Journal of Pure & Applied Science;Can. J. Pure Appl. Sci.
 Canadian Journal of Research;Can. J. Res.
 Canadian Journal of Soil Science;Can. J. Soil Sci.
@@ -748,7 +748,7 @@ Ceramics - Silikaty;Ceram. Silik.
 Ceramics International;Ceram. Int.
 Cereal Chemistry;Cereal Chem.
 Cereal Research Communications;Cereal Res. Commun.
-Chaos, Solitons & Fractals;Chaos Soliton Fract.
+Chaos, Solitons & Fractals;Chaos Solitons Fractals
 Chem-Bio Informatics Journal;Chem-Bio Inf. J.
 ChemBioChem;ChemBioChem
 ChemCatChem;ChemCatChem
@@ -763,7 +763,7 @@ Chemical Education Research and Practice;Chem. Educ. Res. Pract.
 Chemical Education Research and Practice in Europe;CHem. Educ. Res. Pract. Eur.
 Chemical Educator;Chem. Educ.
 Chemical Engineer (London);Chem. Eng. (London)
-Chemical Engineering (New York);Chem. Eng. (New York)
+Chemical Engineering (New York);Chem. Eng. (N. Y.)
 Chemical Engineering Communications;Chem. Eng. Commun.
 Chemical Engineering Education;Chem. Eng. Educ.
 Chemical Engineering Journal;Chem. Eng. J.
@@ -771,7 +771,7 @@ Chemical Engineering Journal and the Biochemical Engineering Journal;Chem. Eng. 
 Chemical Engineering Progress;Chem. Eng. Prog.
 Chemical Engineering Research and Design;Chem. Eng. Res. Des.
 Chemical Engineering Science;Chem. Eng. Sci.
-Chemical Engineering and Processing: Process Intensification;Chem. Eng. Process.
+Chemical Engineering and Processing: Process Intensification;Chem. Eng. Process. Process Intensif.
 Chemical Engineering and Technology;Chem. Eng. Technol.
 Chemical Fibers International;Chem. Fibers Int.
 Chemical Geology;Chem. Geol.
@@ -893,7 +893,7 @@ Combustion Science and Technology;Combust. Sci. Technol.
 Combustion Theory and Modelling;Combust. Theor. Model.
 Combustion and Flame;Combust. Flame
 Comments on Astrophysics;Comments Astrophys.
-Comments on Atomic and Molecular Physics;Comments At. Mo. Phys.
+Comments on Atomic and Molecular Physics;Comments At. Mol. Phys.
 Comments on Condensed Matter Physics;Comments Condens. Matter Phys.
 Comments on Inorganic Chemistry;Comments Inorg. Chem.
 Comments on Modern Physics;Comments Mod. Phys.
@@ -918,18 +918,18 @@ Composites Part A Applied Science and Manufacturing;Composites Part A
 Composites Part B Engineering;Composites Part B
 Composites Science and Technology;Compos. Sci. Technol.
 Comprehensive Series in Photochemistry & Photobiology;Compre. Ser. Photochem. Photobiol.
-Comptes Rendus Biologies;C.R. Biol.
-Comptes Rendus Chimie;C.R. Chim.
-Comptes Rendus Geoscience;C.R. Geosci.
-Comptes Rendus Hebdomadaires des Seances de l'Academie des Sciences;C.R. Hebd. Seances Acad. Sci.
-Comptes Rendus Mathematique;C.R. Math.
-Comptes Rendus Mecanique;C.R. Mec.
-Comptes Rendus Palevol;C.R. Palevol
-Comptes Rendus Physique;C.R. Phys.
-Comptes Rendus de l' Academie des Sciences Serie III: Sciences de la Vie;C.R. Acad. Sci., Ser. III
-Comptes Rendus de l' Academie des Sciences Serie IIa:Sciences de la Terre et des Planets;C.R. Acad. Sci., Ser. IIa: Sci. Terre Planets
-Comptes Rendus de l' Academie des Sciences Serie IIb:Mecanique Physique Chimie Astronomie;C.R. Acad. Sci., Ser. IIb: Mec., Phys., Chim., Astron.
-Comptes Rendus de l' Academie des Sciences Serie IIc:Chemie;C.R. Acad. Sci., Ser. IIc: Chim.
+Comptes Rendus Biologies;C. R. Biol.
+Comptes Rendus Chimie;C. R. Chim.
+Comptes Rendus Geoscience;C. R. Geosci.
+Comptes Rendus Hebdomadaires des Seances de l'Academie des Sciences;C. R. Hebd. Seances Acad. Sci.
+Comptes Rendus Mathematique;C. R. Math.
+Comptes Rendus Mecanique;C. R. Mec.
+Comptes Rendus Palevol;C. R. Palevol
+Comptes Rendus Physique;C. R. Phys.
+Comptes Rendus de l' Academie des Sciences Serie III: Sciences de la Vie;C. R. Acad. Sci., Ser. III
+Comptes Rendus de l' Academie des Sciences Serie IIa:Sciences de la Terre et des Planets;C. R. Acad. Sci., Ser. IIa: Sci. Terre Planets
+Comptes Rendus de l' Academie des Sciences Serie IIb:Mecanique Physique Chimie Astronomie;C. R. Acad. Sci., Ser. IIb: Mec., Phys., Chim., Astron.
+Comptes Rendus de l' Academie des Sciences Serie IIc:Chemie;C. R. Acad. Sci., Ser. IIc: Chim.
 Computation Materials Science;Comput. Mater. Sci.
 Computational Biology and Chemistry;Comput. Biol. Chem.
 Computational Intelligence;Comput. Intell.
@@ -944,8 +944,8 @@ Computer Animation and Virtual Worlds;Comput. Anim. Virtual Worlds
 Computer Communications;Comput. Commun.
 Computer Graphics Forum;Comput. Graphics Forum
 Computer Integrated Manufacturing Systems;Comput. Integr. Manuf. Syst.
-Computer Methods in Applied Mechanics and Engineering;Comput. Meth. Appl. Mech. Eng.
-Computer Methods in Biomechanics and Biomedical Engineering;Comput. Meth. Biomech. Biomed. Eng.
+Computer Methods in Applied Mechanics and Engineering;Comput. Methods Appl. Mech. Eng.
+Computer Methods in Biomechanics and Biomedical Engineering;Comput. Methods Biomech. Biomed. Eng.
 Computer Physics Communications;Comput. Phys. Commun.
 Computer Speech & Language;Comput. Speech Lang.
 Computer Vision and Image Understanding;Comput. Vision Image Understanding
@@ -1022,7 +1022,7 @@ Current Opinion in Colloid and Interface Science;Curr. Opin. Colloid Interface S
 Current Opinion in Drug Discovery & Development;Curr. Opin. Drug Discovery Dev.
 Current Opinion in Environment Sustainability;Curr. Opin. Environ. Sustainability
 Current Opinion in Immunology;Curr. Opin. Immunol.
-Current Opinion in Investigational Drugs;Curr. Opin. Invest. Drugs
+Current Opinion in Investigational Drugs;Curr. Opin. Investig. Drugs
 Current Opinion in Microbiology;Curr. Opin. Microbiol.
 Current Opinion in Molecular Therapeutics;Curr. Opin. Mol. Ther.
 Current Opinion in Neurobiology;Curr. Opin. Neurobiol.
@@ -1032,7 +1032,7 @@ Current Opinion in Solid State and Materials Science;Curr. Opin. Solid State Mat
 Current Opinion in Structural Biology;Curr. Opin. Struct. Biol.
 Current Organic Chemistry;Curr. Org. Chem.
 Current Organic Synthesis;Curr. Org. Synth.
-Current Pharmacogenomics and Personalized Medicine;Curr. Pharm. Pers. Med.
+Current Pharmacogenomics and Personalized Medicine;Curr. Pharmacogenomics Pers. Med.
 Current Plant Science in Biotechnology and Agriculture;Curr. Plant Sci. Biotechnol. Agric.
 Current Separations and Drug Development;Curr. Sep Drug Dev.
 Current Topics in Medicinal Chemistry;Curr. Top. Med. Chem.
@@ -1055,7 +1055,7 @@ Deutsche Gesundheitswesen;Dtsch. Gesundheitswes.
 Deutsche Zeitschrift fur Sportmedizin;Dtsch. Z. Sportmed.
 Deutsche Zeitschrift fur die Gesamte Gerichtliche Medizin;Dtsch. Z. Gesamte Gerichtl. Med.
 Developmental Biology;Dev. Biol.
-Developmental Dynamics;Dev. Dynam.
+Developmental Dynamics;Dev. Dyn.
 Diamond Films and Technology;Diamond Films Technol.
 Diamond and Related Materials;Diamond Relat. Mater.
 Digital Signal Processing;Digital Signal Process.
@@ -1091,7 +1091,7 @@ Earth Interactions;Earth Interact
 Earth Science Frontiers;Earth Sci. Front.
 Earth Science Informatics;Earth Sci. Inf.
 Earth Sciences Research Journal;Earth Sci. Res. J.
-Earth Surface Processes and Landforms;Earth Surf. Processes Landforms
+Earth Surface Processes and Landforms;Earth Surf. Processes Landf.
 Earth and Environmental Science Transactions;Earth Environ. Sci. Trans.
 Earth and Planetary Science Letters;Earth Planet. Sci. Lett.
 Earth-Science Reviews;Earth Sci. Rev.
@@ -1109,7 +1109,7 @@ Ecological Engineering;Ecol. Eng.
 Ecological Entomology;Ecol. Entomol.
 Ecological Indicators;Ecol. Indic.
 Ecological Management and Restoration;Ecol. Manage. Restor.
-Ecological Modelling;Ecol. Modell.
+Ecological Modelling;Ecol. Model.
 Ecological Research;Ecol. Res.
 Economic Botany;Econ. Bot.
 Economic Geology;Econ. Geol.
@@ -1141,11 +1141,11 @@ Electronics Letters;Electron. Lett
 Electronics and Communications in Japan;Electron. Commun. Jpn.
 Elektrotechnik und Maschinenbau;Elektrotech. Maschinenbau
 Elektrotechnische Zeitschrift;Elektrotech. Z.
-Energie Wasser Praxis;Energ. Wasser Prax.
+Energie Wasser Praxis;Energy Wasser Prax.
 Energy & Environment;Energy Environ.
 Energy & Environmental Science;Energy Environ. Sci.
 Energy Conversion and Management;Energy Convers. Manage.
-Energy Efficiency;Energ. Effic.
+Energy Efficiency;Energy Effic.
 Energy Engineering;Energy Eng.
 Energy Exploration & Exploitation;Energy Explor. Exploit.
 Energy Procedia;Energy Procedia
@@ -1192,7 +1192,7 @@ Environmental Health Perspectives;Environ. Health Perspect.
 Environmental Impact Assessment Review;Environ. Impact Assess. Rev.
 Environmental Microbiology;Environ. Microbiol.
 Environmental Modeling and Assessment;Environ. Model. Assess.
-Environmental Modelling and Software;Environ. Modell. Softw.
+Environmental Modelling and Software;Environ. Model. Softw.
 Environmental Monitoring and Assessment;Environ. Monit. Assess.
 Environmental Pollution;Environ. Pollut.
 Environmental Practice;Environ. Pract.
@@ -1279,13 +1279,13 @@ Europhysics Letters;Europhys. Lett.
 Europhysics News;Europhys. News
 Experimental Agriculture;Exp. Agric.
 Experimental Astronomy;Exp. Astron.
-Experimental Cell Research;Exp. Cell. Res.
+Experimental Cell Research;Exp. Cell Res.
 Experimental Heat Transfer;Exp. Heat Transfer
 Experimental Hematology;Exp. Hematol.
 Experimental Mechanics;Exp. Mech.
 Experimental Mycology;Exp. Mycol.
 Experimental Techniques;Exp. Tech.
-Experimental Thermal and Fluid Science;Exp. Therm Fluid Sci.
+Experimental Thermal and Fluid Science;Exp. Therm. Fluid Sci.
 Experimental and Clinical Psychopharmacology;Exp. Clin. Psychopharmacol.
 Experimental and Molecular Pathology;Exp. Mol. Pathol.
 Experimental and Toxicologic Pathology;Exp. Toxicol. Pathol.
@@ -1349,7 +1349,7 @@ Focus on Polyvinyl Chloride;Focus Polyvinyl Chloride
 Focus on Powder Coatings;Focus Powder Coat.
 Focus on Surfactants;Focus Surfactants
 Folding and Design;Fold Des.
-Folia Biologica;Folia Biol.
+Folia Biologica;Folia Biol. (Praha)
 Fonderie Fondeur d'Aujourd'hui;Fonderie Fondeur Aujourd'hui
 Food & Foods Ingredients Journal of Japan;Food Foods Ingredients J. Jpn.
 Food Additives and Contaminants;Food Addit. Contam.
@@ -1411,14 +1411,14 @@ Fresenius Environment bulletin;Fresenius Environ. Bull.
 Fresenius Journal of Analytical Chemistry;Fresenius J. Anal. Chem.
 Frontier Science Series;Front. Sci. Ser.
 Frontiers in Drug Design and Discovery;Front. Drug Des. Discovery
-Frontiers of Chemical Engineering in China;Front. Chem. Eng. Chin.
-Frontiers of Chemistry in China;Front. Chem. Chin.
-Frontiers of Earth Science in China;Front Earth Sci. Chin.
-Frontiers of Electrical and Electronic Engineering in China;Front. Electr. Electron. Eng. Chin.
-Frontiers of Energy and Power Engineering in China;Front. Energy Power Eng. Chin.
-Frontiers of Environmental Science & Engineering in China;Front. Environ. Sci. Eng. Chin.
-Frontiers of Materials Science in China;Front. Mater. Sci. Chin.
-Frontiers of Mechanical Engineering in China;Front. Mech. Eng. Chin.
+Frontiers of Chemical Engineering in China;Front. Chem. Eng. China
+Frontiers of Chemistry in China;Front. Chem. China
+Frontiers of Earth Science in China;Front Earth Sci. China
+Frontiers of Electrical and Electronic Engineering in China;Front. Electr. Electron. Eng. China
+Frontiers of Energy and Power Engineering in China;Front. Energy Power Eng. China
+Frontiers of Environmental Science & Engineering in China;Front. Environ. Sci. Eng. China
+Frontiers of Materials Science in China;Front. Mater. Sci. China
+Frontiers of Mechanical Engineering in China;Front. Mech. Eng. China
 Fuel Cells Bulletin;Fuel Cells Bull.
 Fuel Processing Technology;Fuel Process. Technol.
 Fuel Science and Technology International;Fuel Sci. Technol. Int.
@@ -1486,14 +1486,14 @@ Glass Science and Technology;Glass Sci. Technol.
 Glass Technology;Glass Technol.
 Glass Technology: European Journal of Glass Science and Technology, Part A;Glass Technol.: Eur. J. Glass Sci. Technol., Part A
 Glass and Ceramics;Glass Ceram.
-Global Biogeochemical Cycles;Global Biogeochem. Cycles
-Global Change Biology;Global Change Biol.
-Global Ecology and Biogeography;Global Ecol. Biogeogr.
-Global Environmental Change;Global Environ. Change
-Global Journal of Environmental Sciences;Global J. Environ. Sci.
-Global Journal of Geological Sciences;Global J. Geol. Sci.
-Global Journal of Pure and Applied Sciences;Global J. Pure Appl. Sci.
-Global and Planetary Change;Global Planet. Change
+Global Biogeochemical Cycles;Glob. Biogeochem. Cycles
+Global Change Biology;Glob. Change Biol.
+Global Ecology and Biogeography;Glob. Ecol. Biogeogr.
+Global Environmental Change;Glob. Environ. Change
+Global Journal of Environmental Sciences;Glob. J. Environ. Sci.
+Global Journal of Geological Sciences;Glob. J. Geol. Sci.
+Global Journal of Pure and Applied Sciences;Glob. J. Pure Appl. Sci.
+Global and Planetary Change;Glob. Planet. Change
 Glycoconjugate Journal;Glycoconjugate J.
 Gold Bulletin;Gold Bull.
 Gondwana Research;Gondwana Res.
@@ -1545,7 +1545,7 @@ Hungarian Journal of Industrial Chemistry;Hung. J. Ind. Chem.
 Hydrocarbon Engineering;Hydrocarbon Eng.
 Hydrocarbon Processing, International Edition;Hydrocarbon Process., Int. Ed.
 Hydrogeology Journal;Hydrol. J.
-Hydrological Processes;Hydrol. Processes
+Hydrological Processes;Hydrol. Process.
 Hydrological Sciences Bulletin;Hydrol. Sci. Bull.
 Hydrological Sciences Journal;Hydrol. Sci. J.
 Hydrologie und Wasserbewirtschaftung;Hydrol. Wasserbewirtsch.
@@ -1870,7 +1870,7 @@ International Journal for Numerical Methods in Engineering;Int. J. Numer. Method
 International Journal for Numerical Methods in Fluids;Int. J. Numer. Methods Fluids
 International Journal for Numerical and Analytical Methods in Geomechanics;Int. J. Numer. Anal. Methods Geomech.
 International Journal for Radiation Physics and Chemistry;Int. J. Radiat. Phys. Chem.
-International Journal for Simulation and Multidisciplinary Design Optimization;Int. J. Simul. Multi. Design Optim.
+International Journal for Simulation and Multidisciplinary Design Optimization;Int. J. Simul. Multi. Des. Optim.
 International Journal of Abrasive Technology;Int. J. Abras. Technol.
 International Journal of Acoustics and Vibrations;Int. J. Acoust. Vibr.
 International Journal of Ad Hoc and Ubiquitous Computing;Int. J. Ad Hoc Ubiquitous Comput.
@@ -2007,7 +2007,7 @@ International Journal of Fuzzy Systems;Int. J. Fuzzy Syst.
 International Journal of General Systems;Int. J. Gen. Syst.
 International Journal of Geomagnetism and Aeronomy;Int. J. Geomag. Aeron.
 International Journal of Geomechanics;Int. J. Geomech.
-International Journal of Geometric Methods in Modern Physics;Int. J. Geom. Meth. Mod. Phys.
+International Journal of Geometric Methods in Modern Physics;Int. J. Geom. Methods Mod. Phys.
 International Journal of Geotechnical Engineering;Int. J. Geotech. Eng.
 International Journal of Global Energy Issues;Int. J. Global Energy Issues
 International Journal of Green Energy;Int. J. Green Energy
@@ -2033,7 +2033,7 @@ International Journal of Hydrocarbon Engineering;Int. J. Hydrocarbon Eng.
 International Journal of Hydrogen Energy;Int. J. Hydrogen Energy
 International Journal of Hygiene and Environmental Health;Int. J. Hyg. Environ. Health
 International Journal of Imaging Systems and Technology;Int. J. Imaging Syst. Technol.
-International Journal of Immunopharmacology;Int. J. Immunopharmacol
+International Journal of Immunopharmacology;Int. J. Immunopharmacol.
 International Journal of Impact Engineering;Int. J. Impact Eng.
 International Journal of Industrial Engineering: Theory Applications and Practice;Int. J. Ind. Eng.Theory Appl. Pract.
 International Journal of Industrial Ergonomics;Int. J. Ind. Ergon.
@@ -2115,18 +2115,18 @@ International Journal of Natural and Engineering Sciences;Int. J. Nat. Eng. Sci.
 International Journal of Network Management;Int. J. Network Manage.
 International Journal of Networking and Virtual Organisations;Int. J. Networking Virtual Organ.
 International Journal of Neural Systems;Int. J. Neural Syst.
-International Journal of Neuropsychopharmacology;Int. J. Neuropsychopharmacolog.
+International Journal of Neuropsychopharmacology;Int. J. Neuropsychopharmacol.
 International Journal of Non-Equilibrium Processing;Int. J. Non Equilibr. Process
 International Journal of Non-Linear Mechanics;Int. J. Non Linear Mech.
 International Journal of Nondestructive Testing;Int. J. Nondestr. Test.
-International Journal of Nonlineare Modelling in Science and Engineering;Int. J. Nonlinear Modell. Sci. Eng.
+International Journal of Nonlineare Modelling in Science and Engineering;Int. J. Nonlinear Model. Sci. Eng.
 International Journal of Nuclear Desalination;Int. J. Nucl. Desalin.
 International Journal of Nuclear Energy Science and Technology;Int. J. Nucl. Energy Sci. Technol.
 International Journal of Nuclear Medicine and Biology;Int. J. Nucl. Med. Biol.
 International Journal of Numerical Analysis and Modeling;Int. J. Numer. Anal. Model.
 International Journal of Numerical Methods for Heat and Fluid Flow;Int. J. Numer. Methods Heat Fluid Flow
 International Journal of Numerical Methods in Biomedical Engineering;Int. J. Numer. Methods Biomed. Eng.
-International Journal of Numerical Modelling: Electronic Networks, Devices and Fields;Int. J. Numer. Modell. Electron. Networks Devices Fields
+International Journal of Numerical Modelling: Electronic Networks, Devices and Fields;Int. J. Numer. Model. Electron. Networks Devices Fields
 International Journal of Oceanology and Limnology;Int. J. Oceanol. Limnol.
 International Journal of Offshore and Polar Engineering;Int. J. Offshore Polar Eng.
 International Journal of Oncology;Int. J. Oncol.
@@ -2134,7 +2134,7 @@ International Journal of Optomechatronics;Int. J. Optomechatronics
 International Journal of PIXE;Int. J. PIXE
 International Journal of Parallel Programming;Int. J. Parallel Program.
 International Journal of Parallel, Emergent and Distributed Systems;Int. J. Parallel Emergent Distrib. Syst.
-International Journal of Pattern Recognition and Artificial Intelligence;Int. J. Pattern Recognit Artif Intell.
+International Journal of Pattern Recognition and Artificial Intelligence;Int. J. Pattern Recognit. Artif. Intell.
 International Journal of Pavement Engineering;Int. J. Pavement Eng.
 International Journal of Peptide Research and Therapeutics;Int. J. Pept. Res. Ther.
 International Journal of Peptide and Protein Research;Int. J. Pept. Protein Res.
@@ -2183,7 +2183,7 @@ International Journal of Rotating Machinery;Int. J. Rotating Mach.
 International Journal of Satellite Communications and Networking;Int. J. Satell. Commun. Networking
 International Journal of Security and Networks;Int. J. Secur. Netw.
 International Journal of Sediment Research;Int. J. Sediment Res.
-International Journal of Self-Propagating High-Temperature Synthesis;Int. J. Self Propag. High Temp. Synth.
+International Journal of Self-Propagating High-Temperature Synthesis;Int. J. Self-Propag. High-Temp. Synth.
 International Journal of Services Operations and Informatics;Int. J. Serv. Oper. Inf.
 International Journal of Services, Technology and Management;Int. J. Serv. Technol. Manage.
 International Journal of Shape Modeling;Int. J. Shape Model.
@@ -2191,7 +2191,7 @@ International Journal of Simulation and Process Modelling;Int. J. Simul. Process
 International Journal of Simulation: Systems, Science and Technology;Int. J. Simul. Syst. Sci. Technol.
 International Journal of Smart Sensing and Intelligent Systems;Int. J. Smart Sens. Intell. Syst.
 International Journal of Soft Computing;Int. J. Soft Comput.
-International Journal of Software Engineering and Knowledge Engineering;Int. J. Software Engineer. Knowledge Engineer.
+International Journal of Software Engineering and Knowledge Engineering;Int. J. Software Eng. Knowledge Eng.
 International Journal of Soil Dynamics and Earthquake Engineering;Int. J. Soil Dyn. Earthquake Eng.
 International Journal of Soil Science;Int. J. Soil Sci.
 International Journal of Solids and Structures;Int. J. Solids Struct.
@@ -2213,7 +2213,7 @@ International Journal of Technology Assessment in Health Care;Int. J. Technol. A
 International Journal of Technology Intelligence and Planning;Int. J. Technol. Intell. Plann.
 International Journal of Technology Management;Int. J. Technol. Manage.
 International Journal of Technology and Design Education;Int. J. Technol. Des. Educ.
-International Journal of Technology and Human Interaction;Int. J. Technol. Human Interact.
+International Journal of Technology and Human Interaction;Int. J. Technol. Hum. Interact.
 International Journal of Technology, Policy and Management;Int. J. Technol. Policy Manage.
 International Journal of Theoretical Physics;Int. J. Theor. Phys.
 International Journal of Theoretical Physics, Group Theory, and Nonlinear Optics;Int. J. Theor. Phys. Group Theory Nonlinear Opt.
@@ -2346,7 +2346,7 @@ Journal of Aerospace Engineering;J. Aerosp. Eng.
 Journal of African Earth Sciences;J. Afr. Earth. Sci.
 Journal of Agricultural Engineering Research;J. Agric. Eng. Res.
 Journal of Agricultural Science;J. Agric. Sci.
-Journal of Agricultural and Food Chemistry;J. Agric. Food. Chem.
+Journal of Agricultural and Food Chemistry;J. Agric. Food Chem.
 Journal of Agroalimentary Processes and Technologies;J. Agroaliment. Proc. Technol.
 Journal of Alloys and Compounds;J. Alloys Compd.
 Journal of Alzheimer's Disease;J. Alzheimers Dis.
@@ -2391,7 +2391,7 @@ Journal of Applied Systems Analysis;J. Appl. Syst. Anal.
 Journal of Applied Toxicology;J. Appl. Toxicol.
 Journal of Applied and Industrial Mathematics;J. Appl. Ind. Math.
 Journal of Aquatic Food Product Technology;J. Aquat. Food Prod. Technol.
-Journal of Archaeological Science;J. Archaeolog. Sci.
+Journal of Archaeological Science;J. Archaeol. Sci.
 Journal of Architectural Engineering;J. Archit. Eng.
 Journal of Arid Environments;J. Arid. Environ.
 Journal of Asia-Pacific Entomology;J. Asia-Pac. Entomol.
@@ -2445,8 +2445,8 @@ Journal of Bone and Mineral Metabolism;J. Bone Miner. Metab.
 Journal of Bone and Mineral Research;J. Bone Miner. Res.
 Journal of Breath Research;J. Breath Res.
 Journal of Bridge Engineering;J. Bridge Eng.
-Journal of Building Performance Simulation;J. Building Perform. Simul.
-Journal of Building Physics;J. Building Phys.
+Journal of Building Performance Simulation;J. Build. Perform. Simul.
+Journal of Building Physics;J. Build. Phys.
 Journal of Canadian Petroleum Technology;J. Can. Pet. Technol.
 Journal of Cancer Molecules;J. Cancer Mol.
 Journal of Carbohydrate Chemistry;J. Carbohydr. Chem.
@@ -2579,18 +2579,18 @@ Journal of Environmental Policy & Planning;J. Environ. Plann. Policy Manage.
 Journal of Environmental Protection and Ecology;J. Environ. Prot. Ecol.
 Journal of Environmental Quality;J. Environ. Qual.
 Journal of Environmental Radioactivity;J. Environ. Radioact.
-Journal of Environmental Science and Health, Part A Environmental Science;J. Environ. Sci. Health., Part A
-Journal of Environmental Science and Health, Part A: Environmental Science and Engineering;J. Environ. Sci. Health. Part A Environ. Sci. Health Part A Environ. Sci. Eng
-Journal of Environmental Science and Health, Part A: Environmental Science and Engineering & Toxic and Hazardous Substance Control;J. Environ. Sci. Health., Part A Environ. Sci. Eng.Toxic Hazard. Subst. Control
-Journal of Environmental Science and Health, Part A: Toxic/Hazardous Substances & Environmental Engineering;J. Environ. Sci. Health. Part A Toxic/Hazard. Subst. Environ. Eng.
-Journal of Environmental Science and Health, Part B Pesticides;J. Environ. Sci. Health., Part B
-Journal of Environmental Science and Health, Part B: Pesticides, Food Contaminants, and Agricultural Wastes;J. Environ. Sci. Health., Part B
-Journal of Environmental Science and Health, Part C: Environmental Carcinogenesis & Ecotoxicology Reviews;J. Environ. Sci. Health., Part C Environ. Carcinog. Ecotoxicol. Rev.
+Journal of Environmental Science and Health, Part A Environmental Science;J. Environ. Sci. Health. A
+Journal of Environmental Science and Health, Part A: Environmental Science and Engineering;J. Environ. Sci. Health A Environ. Sci. Health Part A: Environ. Sci. Eng
+Journal of Environmental Science and Health, Part A: Environmental Science and Engineering & Toxic and Hazardous Substance Control;J. Environ. Sci. Health. A: Environ. Sci. Eng.Toxic Hazard. Subst. Control
+Journal of Environmental Science and Health, Part A: Toxic/Hazardous Substances & Environmental Engineering;J. Environ. Sci. Health A: Toxic/Hazard. Subst. Environ. Eng.
+Journal of Environmental Science and Health, Part B Pesticides;J. Environ. Sci. Health B
+Journal of Environmental Science and Health, Part B: Pesticides, Food Contaminants, and Agricultural Wastes;J. Environ. Sci. Health B
+Journal of Environmental Science and Health, Part C: Environmental Carcinogenesis & Ecotoxicology Reviews;J. Environ. Sci. Health C: Environ. Carcinog. Ecotoxicol. Rev.
 Journal of Environmental Science and Health, Part C: Environmental Carcinogenesis Reviews;J. Environ. Sci. Health., Part C Environ. Carcinog. Rev.
 Journal of Environmental Science and Health, Part C: Environmental Health Sciences;J. Environ. Sci. Health., Part C Environ. Health Sci.
 Journal of Environmental Science and Technology;J. Environ. Sci. Technol.
 Journal of Environmental and Engineering Geophysics;J. Environ. Eng. Geophys.
-Journal of Enzyme Inhibition;J. Enzym Inhib.
+Journal of Enzyme Inhibition;J. Enzyme Inhib.
 Journal of Enzyme Inhibition and Medicinal Chemistry;J. Enzyme Inhib. Med. Chem.
 Journal of Essential Oil Research;J. Essent. Oil Res.
 Journal of Essential Oil-Bearing Plants;J. Essent. Oil Bear. Plants
@@ -2621,7 +2621,7 @@ Journal of Food Biochemistry;J. Food Biochem.
 Journal of Food Composition and Analysis;J. Food Compos. Anal.
 Journal of Food Engineering;J. Food Eng.
 Journal of Food Lipids;J. Food Lipids
-Journal of Food Process Engineering;J. Food Process Eng
+Journal of Food Process Engineering;J. Food Process Eng.
 Journal of Food Processing and Preservation;J. Food Process. Preserv.
 Journal of Food Protection;J. Food Prot.
 Journal of Food Quality;J. Food Qual.
@@ -2667,7 +2667,7 @@ Journal of Geophysical Research, Oceans;J. Geophys. Res. Oceans
 Journal of Geophysical Research, Planets;J. Geophys. Res. Planets
 Journal of Geophysical Research, Solid Earth;J. Geophys. Res. Solid Earth
 Journal of Geophysical Research, Space Physics;J. Geophys. Res. Space Phys.
-Journal of Geophysical Research, [Atmospheres];J. Geophys. Res. Atmos.
+Journal of Geophysical Research, [Atmospheres];J. Geophys. Res. [Atmos.]
 Journal of Geophysics;J. Geophys.
 Journal of Geophysics and Engineering;J. Geophys. Eng.
 Journal of Geoscience Education;J. Geosci. Educ.
@@ -2733,7 +2733,7 @@ Journal of Light & Visual Environment;J. Light Visual Environ.
 Journal of Light Metals;J. Light Met.
 Journal of Lightwave Technology;J. Lightwave Technol.
 Journal of Lipid Mediators;J. Lipid Mediators
-Journal of Lipid Mediators and Cell Signalling;J. Lipid Mediators Cell Signalling
+Journal of Lipid Mediators and Cell Signalling;J. Lipid Mediat. Cell Signal.
 Journal of Lipid Research;J. Lipid Res.
 Journal of Liposome Research;J. Liposome Res.
 Journal of Liquid Chromatography;J. Liq. Chromatogr.
@@ -2747,12 +2747,12 @@ Journal of Macromolecular Science - Physics;J. Macromol. Sci., Phys.
 Journal of Macromolecular Science - Reviews in Macromolecular Chemistry and Physics;J. Macromol. Sci., Rev. Macromol. Chem. Phys.
 Journal of Macromolecular Science Polymer Reviews;J. Macromol. Sci., Polym. Rev.
 Journal of Macromolecular Science Pure and Applied Chemistry;J. Macromol. Sci., Pure Appl. Chem.
-Journal of Macromolecular Science, Part A Pure and Applied Chemistry;J. Macromol. Sci. Part A Pure Appl. Chem.
-Journal of Macromolecular Science, Part B Physics;J. Macromol. Sci. Part B Phys.
+Journal of Macromolecular Science, Part A Pure and Applied Chemistry;J. Macromol. Sci. A Pure Appl. Chem.
+Journal of Macromolecular Science, Part B Physics;J. Macromol. Sci. B Phys.
 Journal of Magnetic Resonance;J. Magn. Reson.
 Journal of Magnetic Resonance Imaging;J. Magn. Reson. Imaging
-Journal of Magnetic Resonance Series A;J. Magn. Reson., Ser. A
-Journal of Magnetic Resonance Series B;J. Magn. Reson., Ser. B
+Journal of Magnetic Resonance Series A;J. Magn. Reson. A
+Journal of Magnetic Resonance Series B;J. Magn. Reson. B
 Journal of Magnetism and Magnetic Materials;J. Magn. Magn. Mater.
 Journal of Management in Engineering;J. Manage. Eng.
 Journal of Manufacturing Processes;J. Manuf. Processes
@@ -2823,7 +2823,7 @@ Journal of Molecular Catalysis A: Chemical;J. Mol. Catal. A: Chem.
 Journal of Molecular Catalysis B: Enzymatic;J. Mol. Catal. B: Enzym.
 Journal of Molecular Cell Biology;J. Mol. Cell. Biol.
 Journal of Molecular Graphics;J. Mol. Graphics
-Journal of Molecular Graphics and Modelling;J. Mol. Graphics Modell.
+Journal of Molecular Graphics and Modelling;J. Mol. Graphics Model.
 Journal of Molecular Liquids;J. Mol. Liq.
 Journal of Molecular Medicine;J. Mol. Med.
 Journal of Molecular Microbiology and Biotechnology;J. Mol. Microbiol. Biotechnol.
@@ -2872,10 +2872,10 @@ Journal of Nondestructive Evaluation;J. Nondestr. Eval.
 Journal of Nonlinear Mathematical Physics;J. Nonlinear Math. Phys.
 Journal of Nonlinear Optical Physics and Materials;J. Nonlinear Opt. Phys. Mater.
 Journal of Nuclear Biology and Medicine;J. Nucl. Biol. Med.
-Journal of Nuclear Energy;J. Nucl. Eng.
-Journal of Nuclear Energy, Part A: Reactor Science;J. Nucl. Eng. Part A:
-Journal of Nuclear Energy, Part B: Reactor Technology;J. Nucl. Eng. Part B:
-Journal of Nuclear Energy. Part C, Plasma Physics, Accelerators, Thermonuclear Research;J. Nucl. Eng. Part C:
+Journal of Nuclear Energy;J. Nucl. Energy
+Journal of Nuclear Energy, Part A: Reactor Science;J. Nucl. Energy A
+Journal of Nuclear Energy, Part B: Reactor Technology;J. Nucl. Energy B
+Journal of Nuclear Energy. Part C, Plasma Physics, Accelerators, Thermonuclear Research;J. Nucl. Energy C
 Journal of Nuclear Materials;J. Nucl. Mater.
 Journal of Nuclear Medicine;J. Nucl. Med.
 Journal of Nuclear Science and Technology;J. Nucl. Sci. Technol.
@@ -2883,7 +2883,7 @@ Journal of Nuclear and Radiochemical Sciences;J. Nucl. Radiochem. Sci.
 Journal of Nutrition;J. Nutr.
 Journal of Nutritional & Environmental Medicine;J. Nutr. Environ. Med.
 Journal of Nutritional Biochemistry;J. Nutr. Biochem.
-Journal of Ocean University of China (English Edition);J. Ocean Univ. Chin.
+Journal of Ocean University of China (English Edition);J. Ocean Univ. China
 Journal of Oceanography;J. Oceanogr.
 Journal of Offshore Mechanics and Arctic Engineering;J. Offshore Mech. Arct. Eng.
 Journal of Operations Management;J. Oper. Manage.
@@ -3030,7 +3030,7 @@ Journal of Superconductivity;J. Supercond.
 Journal of Superconductivity and Novel Magnetism;J. Supercond. Novel Magn.
 Journal of Supercritical Fluids;J. Supercrit. Fluids
 Journal of Superhard Materials;J. Superhard Mater.
-Journal of Supramolecular Chemistry;J. Supramolecular Chemistry
+Journal of Supramolecular Chemistry;J. Supramol. Chem.
 Journal of Surface Investigation: X-ray, Synchrotron and Neutron Techniques;J. Surf. Invest.
 Journal of Surfactants and Detergents;J. Surfactants Deterg.
 Journal of Surveying Engineering;J. Surv. Eng.
@@ -3109,7 +3109,7 @@ Journal of the American College of Nutrition;J. Am. Coll. Nutr.
 Journal of the American Leather Chemists Association;J. Am. Leather Chem. Assoc.
 Journal of the American Mosquito Control Association;J. Am. Mosq. Control Assoc.
 Journal of the American Oil Chemists Society;J. Am. Oil Chem. Soc.
-Journal of the American Society for Mass Spectrometry;J. Am. Soc. Mass. Spectrom.
+Journal of the American Society for Mass Spectrometry;J. Am. Soc. Mass Spectrom.
 Journal of the American Society of Brewing Chemists;J. Am. Soc. Brew. Chem.
 Journal of the American Society of Naval Engineers;J. Am. Soc. Naval Eng.
 Journal of the American Water Resources Association;J. Am. Water Resour. Assoc.
@@ -3384,14 +3384,14 @@ Mathematical Geology;Math. Geol.
 Mathematical Geosciences;Math. Geosci.
 Mathematical Medicine and Biology;Math. Med. Biol.
 Mathematical Modeling and Computation;Math. Model. Comput.
-Mathematical Modelling: Theory and Applications;Math. Modell. Theory Appl.
+Mathematical Modelling: Theory and Applications;Math. Model. Theory Appl.
 Mathematical Models and Computer Simulations;Math. Models Comput. Simul.
 Mathematical Models and Methods in Applied Sciences;Math. Models Methods Appl. Sci.
 Mathematical Physics Analysis and Geometry;Math. Phys. Anal. Geom.
 Mathematical Proceedings of the Cambridge Philosophical Society;Math. Proc. Cambridge Philos. Soc.
 Mathematical Programming;Math. Program.
-Mathematical and Computer Modelling;Math. Comput. Modell.
-Mathematical and Computer Modelling of Dynamical Systems;Math. Comput. Modell. Dyn. Syst.
+Mathematical and Computer Modelling;Math. Comput. Model.
+Mathematical and Computer Modelling of Dynamical Systems;Math. Comput. Model. Dyn. Syst.
 Mathematics and Computers in Simulation;Math. Comput. Simul
 Mathematics of Computation;Math. Comput.
 Mathematicsl Methods in the Applied Sciences;Math. Methods Appl. Sci.
@@ -3488,7 +3488,7 @@ Mining and Scientific Press;Min. Sci. Press
 Mitteilungen - Gesellschaft Deutscher Chemiker - Fachgruppe Geschichte der Chemie;Mitt. Gesell. Dtscher. Chem. Fachgruppe Gesch. Chem.
 Mitteilungen Internationale Vereinigung fur Theoretische und Angewandte Limnologie;Mitt. Int. Ver. Theor. Angew. Limnol.
 Modelling Measurement & Control C;Modell. Meas. Control C
-Modelling and Simulation in Materials Science and Engineering;Modell. Simul. Mater. Sci. Eng.
+Modelling and Simulation in Materials Science and Engineering;Model. Simul. Mater. Sci. Eng.
 Modern Drug Discovery;Mod. Drug Discovery
 Modern Physics Letters A;Mod. Phys. Lett. A
 Modern Physics Letters B;Mod. Phys. Lett. B
@@ -3503,7 +3503,7 @@ Molecular Ecology Resources;Mol. Ecol. Resour.
 Molecular Imaging & Biology;Mol. Imag. Biol.
 Molecular Informatics;Mol. Inf.
 Molecular Interventions;Mol. Interventions
-Molecular Marine Biology and Biotechnology;Mol. Mar. Biol. Biotech.
+Molecular Marine Biology and Biotechnology;Mol. Mar. Biol. Biotechnol.
 Molecular Membrane Biology;Mol. Membr. Biol.
 Molecular Microbiology;Mol. Microbiol.
 Molecular Nutrition & Food Research;Mol. Nutr. Food Res.
@@ -3558,7 +3558,7 @@ Nanoscale and Microscale Thermophysical Engineering;Nanoscale Microscale Thermop
 Nanoscience and Nanotechnolog Letters;Nanosci. Nanotechnol. Lett.
 Nanostructured Materials;Nanostruct. Mater.
 Nanotechnologies in Russia;Nanotechnol. Russ.
-Natural Hazards Review;nat. Hazard. Rev.
+Natural Hazards Review;Nat. Hazard. Rev.
 Natural Product Reports;Nat. Prod. Rep.
 Natural Product Research;Nat. Prod. Res.
 Natural Product Research Part A: Structure and Synthesis;Nat. Prod. Res., Part A
@@ -3700,7 +3700,7 @@ Nutrition Research Reviews;Nutr. Res. Rev.
 Ocean Dynamics;Ocean Dyn.
 Ocean Engineering;Ocean Eng.
 Ocean Manage.;Ocean Manage.
-Ocean Modelling;Ocean Modell.
+Ocean Modelling;Ocean Model.
 Ocean Physics and Engineering;Ocean Phys. Eng.
 Ocean Science;Ocean Sci.
 Ocean Science Discussions;Ocean Sci. Discuss.
@@ -3711,7 +3711,7 @@ Ocean and Polar Research;Ocean Polar Res.
 Oceanographic Magazine;Oceanogr. Mag.
 Oceanographic and Marine Biology;Oceanogr. Mar. Biol.
 Oceanologica Acta;Oceanolog. Acta
-Oesterreichische Wasser- und Abfallwirtschaft;Oesterr. Wasser Abfallwirtsch.
+Österreichische Wasser- und Abfallwirtschaft;Österr. Wasser- Abfallwirtsch.
 Oil and Chemical Pollution;Oil Chem. Pollut.
 Oil and Gas International;Oil Gas Int.
 Oil and Gas Journal;Oil Gas J.
@@ -4075,14 +4075,14 @@ Progress in Organic Coatings;Prog. Org. Coat.
 Progress in Paper Recycling;Prog. Pap. Recycl.
 Progress in Particle and Nuclear Physics;Prog. Part. Nucl. Phys.
 Progress in Photovoltaics: Research and Applications;Prog. Photovoltaics Res. Appl.
-Progress in Physical Geography;Prog. Phys. Geog.
+Progress in Physical Geography;Prog. Phys. Geogr.
 Progress in Polymer Science;Prog. Polym. Sci.
 Progress in Quantum Electronics;Prog. Quantum Electron.
 Progress in Reaction Kinetics;Prog. React. Kinet.
 Progress in Solid State Chemistry;Prog. Solid State Chem.
 Progress in Structural Engineering and Materials;Prog. Struct. Mater. Eng.
 Progress in Surface Science;Prog. Surf. Sci.
-Progress in the Chemistry of Fats and Other Lipids;Prog. Chem. Fats Other Lipds
+Progress in the Chemistry of Fats and Other Lipids;Prog. Chem. Fats Other Lipids
 Progress in the Chemistry of Organic Natural Products;Prog. Chem. Org. Nat. Prod.
 Propellants, Explosives, Pyrotechnics;Propellants Explos. Pyrotech.
 Protection of Metals;Prot. Met.
@@ -4161,7 +4161,7 @@ Reactive and Functional Polymers;React. Funct. Polym.
 Recueil des Travaux Chimiques des Pays-Bas;Recl. Trav. Chim. Pays-Bas
 Refractories and Industrial Ceramics;Refract. Ind. Ceram
 Regulatory Peptides;Regul. Pept.
-Regulatory Toxicology and Pharmacology;Regul. Toxicol. Pharm.
+Regulatory Toxicology and Pharmacology;Regul. Toxicol. Pharmacol.
 Reinforced Plastics;Reinf. Plast.
 Reinforced Plastics and Composites World;Reinf. Plast. Compos. World
 Reliability Engineerign;Reliab. Eng.
@@ -4374,7 +4374,7 @@ Signal Processing;Signal Process.
 Signal Processing: Image Communication;Signal Process. Image Commun.
 Silicates Industriels;Silic. Indus.
 Silicon Chemistry;Silicon Chem.
-Simulation Modelling Practice and Theory;Simul. Modell. Pract. Theory
+Simulation Modelling Practice and Theory;Simul. Model. Pract. Theory
 Simulation Practice and Theory;Simul. Pract. Theory
 Sitzungsberichte Bayerische Akademie der Wissenschaften, Mathematische - Naturwissenschaftliche Klasse;Sitzungsber. Bayer. Akad. Wiss. Math. Naturwiss. Kl.
 Sitzungsberichte der Heidelberger Akademie der Wissenschaften, Mathematische - Naturwissenschaftliche Klasse;Sitzungsber. Heidelb. Akad. Wiss. Math. Naturwiss. Kl.

--- a/journals/journal_abbreviations_meteorology.csv
+++ b/journals/journal_abbreviations_meteorology.csv
@@ -11,13 +11,13 @@ Atmospheric Environment;Atmos. Environ.
 Atmospheric Research;Atmos. Res.
 Atmósphera;Atmósphera
 Australian Journal of Agricultural Research;Aust. J. Agric. Res.
-Australian Meteorological Magazine;Aust. Meteor. Mag.
+Australian Meteorological Magazine;Aust. Meteorol. Mag.
 Beitraege zur Physik der Atmosphaere;Beitr. Phys. Atmos.
-Boundary-Layer Meteorology;Bound.-Layer Meteor.
-Bulletin of the American Meteorological Society;Bull. Amer. Meteor. Soc.
+Boundary-Layer Meteorology;Bound.-Layer Meteorol.
+Bulletin of the American Meteorological Society;Bull. Amer. Meteorol. Soc.
 Chemical Engineering Science;Chem. Eng. Sci.
-Climate Dynamics;Climate Dyn.
-Climatic Change;Climatic Change
+Climate Dynamics;Clim. Dyn.
+Climatic Change;Clim. Change
 Climatological Bulletin;Climatol. Bull.
 Communications on Pure and Applied Mathematics;Commun. Pure Appl. Math.
 Continental Shelf Research;Cont. Shelf Res.
@@ -46,13 +46,13 @@ International Journal of Remote Sensing;Int. J. Remote Sens.
 Izvestiya, Academy of Sciences, USSR, Atmospheric;Izv. Acad. Sci. USSR, Atmos. Oceanic Phys.
 Journal de Recherches Atmospheriques;J. Rech. Atmos.
 Journal of Aerosol Science;J. Aerosol Sci.
-Journal of Applied Meteorology;J. Appl. Meteor.
+Journal of Applied Meteorology;J. Appl. Meteorol.
 Journal of Applied Physics;J. Appl. Phys.
 Journal of Atmospheric and Oceanic Technology;J. Atmos. Oceanic Technol.
 Journal of Atmospheric and Terrestrial Physics;J. Atmos. Terr. Phys.
 Journal of Climate;J. Climate
-Journal of Climate Meteorology;J. Climate Meteor.
-Journal of Climate and Applied Meteorology;J. Climate Appl. Meteor.
+Journal of Climate Meteorology;J. Clim. Meteorol.
+Journal of Climate and Applied Meteorology;J. Clim. Appl. Meteorol.
 Journal of Climatology;J. Climatol.
 Journal of Computational Physics;J. Comput. Phys.
 Journal of Fluid Mechanics;J. Fluid Mech.
@@ -62,31 +62,31 @@ Journal of Glaciology;J. Glaciol.
 Journal of Hydrology;J. Hydrol.
 Journal of Marine Research;J. Mar. Res.
 Journal of Marine Systems;J. Mar. Syst.
-Journal of Meteorological Research, Japan;J. Meteor. Res. Japan
-Journal of Meteorology;J. Meteor.
+Journal of Meteorological Research, Japan;J. Meteorol. Res. Japan
+Journal of Meteorology;J. Meteorol.
 Journal of Physical Chemistry;J. Phys. Chem.
 Journal of Physical Oceanography;J. Phys. Oceanogr.
 Journal of Scientific Instruments;J. Sci. Instrum.
 Journal of the Aeronautical Sciences;J. Aeronaut. Sci.
 Journal of the Atmospheric Sciences;J. Atmos. Sci.
 Journal of the Marine Technology Society;J. Mar. Technol. Soc.
-Journal of the Meteorological Society of Japan;J. Meteor. Soc. Japan
-Journal of the Oceanographical Society of Japan;J. Oceanogr. Soc. Japan
+Journal of the Meteorological Society of Japan;J. Meteorol. Soc. Jpn.
+Journal of the Oceanographical Society of Japan;J. Oceanogr. Soc. Jpn.
 Mariners Weather Log;Mar. Wea. Log
-Meteorological Magazine;Meteor. Mag.
-Meteorological Monographs;Meteor. Monogr.
+Meteorological Magazine;Meteorol. Mag.
+Meteorological Monographs;Meteorol. Monogr.
 Meteorologische Rundschau;Meteor. Rundsch.
 Meteorologische Zeitschrift;Meteor. Z.
 Meteorologiya i Gidrologiya;Meteor. Gidrol.
-Meteorology and Atmospheric Physics;Meteor. Atmos. Phys.
+Meteorology and Atmospheric Physics;Meteorol. Atmos. Phys.
 Monthly Weather Review;Mon. Wea. Rev.
 National Weather Digest;Natl. Wea. Dig.
 Nature;Nature
 New Zealand Journal of Marine and Freshwater Research;N. Z. J. Mar. Freshwater Res.
 Nuovo Cimento;Nuovo Cimento
-Oceanography and Meteorology;Oceanogr. Meteor.
-Papers in Meteorology and Geophysics;Pap. Meteor. Geophys.
-Papers in Physical Oceanography and Meteorology;Pap. Phys. Oceanogr. Meteor.
+Oceanography and Meteorology;Oceanogr. Meteorol.
+Papers in Meteorology and Geophysics;Pap. Meteorol. Geophys.
+Papers in Physical Oceanography and Meteorology;Pap. Phys. Oceanogr. Meteorol.
 Philosophical Transactions of the Royal Society of London;Philos. Trans. Roy. Soc. London
 Physical Review;Phys. Rev.
 Physical Review Letters;Phys. Rev. Lett.
@@ -95,7 +95,7 @@ Physics of Fluids;Phys. Fluids
 Physikalische Zeitschrift;Phys. Z.
 Proceedings of the Royal Society of London;Proc. Roy. Soc. London
 Pure and Applied Geophysics;Pure Appl. Geophys.
-Quarterly Journal of the Royal Meteorological Society;Quart. J. Roy. Meteor. Soc.
+Quarterly Journal of the Royal Meteorological Society;Quart. J. Roy. Meteorol. Soc.
 Radio Science;Radio Sci.
 Remote Sensing of the Environment;Remote Sens. Environ.
 Review of Scientific Instruments;Rev. Sci. Instrum.

--- a/journals/journal_abbreviations_sociology.csv
+++ b/journals/journal_abbreviations_sociology.csv
@@ -1,8 +1,8 @@
 Acta Sociologica;Acta Sociol.
 Agriculture And Human Values;Agric. Human Values
 American Journal Of Economics And Sociology;Am. J. Econ. Sociol.
-American Journal Of Sociology;Am J Sociol
-American Sociological Review;Am Sociol Rev
+American Journal Of Sociology;Am. J. Sociol.
+American Sociological Review;Am. Sociol. Rev.
 Annals Of Tourism Research;Ann. Touris. Res.
 Annual Review Of Sociology;Annu. Rev. Sociol.
 Archives Europeennes De Sociologie;Arch. Eur. Sociol.


### PR DESCRIPTION
I used a script to backport >800 missing entries from https://github.com/JabRef/jabref/blob/master/src/main/resources/journals/journalList.csv to `journal_abbreviations_general.csv`.

I manually checked ~270 entries where the abbreviations or journal names were not matching between this repository and `journalList.csv` (mostly typos, missing or extra dots).

From the list in https://github.com/JabRef/jabref/pull/5749#issuecomment-566236088 I checked/backported the following:
- https://github.com/JabRef/jabref/commit/2ca00841aedd362715f6f8304d206799c268d3db
- https://github.com/JabRef/jabref/commit/40baaa41ae4ba1115e673c32d41f6421ce1cf063
- https://github.com/JabRef/jabref/pull/4376
- https://github.com/JabRef/jabref/pull/4412
- https://github.com/JabRef/jabref/pull/4524
- https://github.com/JabRef/jabref/issues/4529
- https://github.com/JabRef/jabref/commit/f1bbbb7c7a1f571861b79bfb21789829893c4991