### PR TITLE
Fix journal name "Computational Materials Science"

### DIFF
--- a/journals/journal_abbreviations_general.csv
+++ b/journals/journal_abbreviations_general.csv
@@ -999,7 +999,7 @@ Comptes Rendus Mathematique;C .R. Math.
 Comptes Rendus Mecanique;C .R. Mec.
 Comptes Rendus Palevol;C. R. Palevol
 Comptes Rendus Physique;C. R. Phys.
-Computation Materials Science;Comput. Mater. Sci.
+Computational Materials Science;Comput. Mater. Sci.
 Computational and Theoretical Polymer Science;Comput. Theor. Polym. Sci.
 Computational Biology and Chemistry;Comput. Biol. Chem.
 Computational Science & Discovery;Comput. Sci. Discovery

--- a/journals/journal_abbreviations_mechanical.csv
+++ b/journals/journal_abbreviations_mechanical.csv
@@ -930,7 +930,7 @@ Comptes Rendus de l' Academie des Sciences Serie III: Sciences de la Vie;C.R. Ac
 Comptes Rendus de l' Academie des Sciences Serie IIa:Sciences de la Terre et des Planets;C.R. Acad. Sci., Ser. IIa: Sci. Terre Planets
 Comptes Rendus de l' Academie des Sciences Serie IIb:Mecanique Physique Chimie Astronomie;C.R. Acad. Sci., Ser. IIb: Mec., Phys., Chim., Astron.
 Comptes Rendus de l' Academie des Sciences Serie IIc:Chemie;C.R. Acad. Sci., Ser. IIc: Chim.
-Computation Materials Science;Comput. Mater. Sci.
+Computational Materials Science;Comput. Mater. Sci.
 Computational Biology and Chemistry;Comput. Biol. Chem.
 Computational Intelligence;Comput. Intell.
 Computational Materials Science;Comput. Mater. Sci.

--- a/journals/journal_abbreviations_mechanical.csv
+++ b/journals/journal_abbreviations_mechanical.csv
@@ -930,7 +930,6 @@ Comptes Rendus de l' Academie des Sciences Serie III: Sciences de la Vie;C.R. Ac
 Comptes Rendus de l' Academie des Sciences Serie IIa:Sciences de la Terre et des Planets;C.R. Acad. Sci., Ser. IIa: Sci. Terre Planets
 Comptes Rendus de l' Academie des Sciences Serie IIb:Mecanique Physique Chimie Astronomie;C.R. Acad. Sci., Ser. IIb: Mec., Phys., Chim., Astron.
 Comptes Rendus de l' Academie des Sciences Serie IIc:Chemie;C.R. Acad. Sci., Ser. IIc: Chim.
-Computational Materials Science;Comput. Mater. Sci.
 Computational Biology and Chemistry;Comput. Biol. Chem.
 Computational Intelligence;Comput. Intell.
 Computational Materials Science;Comput. Mater. Sci.


### PR DESCRIPTION
Always thank you so much for JabRef developers for this wonderful tool.

Here I submit a very minor request about the journal "Computational Materials Science".
As far as I know and as far as I quickly googled, there is no journal named "Computation Materials Science", while I often read the papers from "Computational Materials Science".
While both may be abbreviated as "Comput. Mater. Sci.", unfortunately in JabRef 5.0, the (maybe wrong) former seems to take the priority.
Also in  "journals/journal_abbreviations_mechanical.csv", just three lines below of "Computation Materials Science", there exists "Computational Materials Science".
This pull request may solve them.