### PR TITLE
Added IEEE list, moved mathscinet

### DIFF
--- a/combine_journal_lists_dots.py
+++ b/combine_journal_lists_dots.py
@@ -17,10 +17,11 @@ import sys
 
 import_order = [
   'journals/journal_abbreviations_acs.csv',
+  'journals/journal_abbreviations_mathematics.csv',
   'journals/journal_abbreviations_ams.csv',
   'journals/journal_abbreviations_geology_physics.csv',
+  'journals/journal_abbreviations_ieee.csv',
   'journals/journal_abbreviations_lifescience.csv',
-  'journals/journal_abbreviations_mathematics.csv',
   'journals/journal_abbreviations_mechanical.csv',
   'journals/journal_abbreviations_meteorology.csv',
   'journals/journal_abbreviations_sociology.csv',


### PR DESCRIPTION
* Integrate IEEE list in merge script (if it is not kept separate in JabRef any more).
* mathematics.csv can be automatically compiled, but MathSciNet does not always stick to ISO, so AMS list should have higher priority.