### PR TITLE
Better abbreviation of Europhys. Lett.

### DIFF
--- a/journals/journal_abbreviations_geology_physics.csv
+++ b/journals/journal_abbreviations_geology_physics.csv
@@ -253,7 +253,7 @@ EPJ Quantum Technology;EPJ Quantum Technol.
 EPJ Special Topics;EPJ Special Topics
 EPJ Techniques and Instrumentation;EPJ Tech. Instrum.
 EPJ Web of Conferences;EPJ Web Conf.
-EPL (Europhysics Letters);EPL (Europhys. Lett.)
+EPL (Europhysics Letters);Europhys. Lett.
 e-Journal of Surface Science and Nanotechnology;E-J. Surf. Sci. Nanotechnol.
 Earth Planets Space [formerly Journal of Geomagnetism and Geoelectricity];Earth Planets Space
 Earth Science Frontiers;Earth Sci. Front.
@@ -275,6 +275,7 @@ European Journal of Mineralogy;Eur. J. Mineral.
 European Journal of Phycology;Eur. J. Phycol.
 European Journal of Physics;Eur. J. Phys.
 Europhysics Letters;Europhys. Lett.
+Europhysics Letters (EPL);Europhys. Lett.
 Experimental Astronomy;Exp. Astron.
 Experimental Heat Transfer;Exp. Heat Transfer
 Experimental Hematology;Exp. Hematol.


### PR DESCRIPTION
Abbreviating as "EPL (Europhys. Lett.)" is pretty redundant.
Also added an abbreviation for "Europhysics Letters (EPL)" which appears in some databases.