### PR TITLE
JOSA A and JOSA B without suffix

### DIFF
--- a/journals/journal_abbreviations_general.csv
+++ b/journals/journal_abbreviations_general.csv
@@ -3319,6 +3319,8 @@ Journal of the National Cancer Institute (1988);J. Natl. Cancer Inst.
 Journal of the Optical Society of America;J. Opt. Soc. Am.
 Journal of the Optical Society of America A: Optics, Image Science, and Vision;J. Opt. Soc. Am. A
 Journal of the Optical Society of America B: Optical Physics;J. Opt. Soc. Am. B
+Journal of the Optical Society of America A;J. Opt. Soc. Am. A
+Journal of the Optical Society of America B;J. Opt. Soc. Am. B
 Journal of the Optical Society of Korea;J. Opt. Soc. Korea;;
 Journal of the Physical Society of Japan;J. Phys. Soc. Jpn.
 Journal of the Royal Statistical Society;J. R. Stat. Soc.


### PR DESCRIPTION
When importing a .bib citation from the official Optica website, the Optical Physics" suffix is no longer appended to the journal name.
The same goes with JOSA A.
However, old citations may still use this notation.
So we need to have both writings.