### PR TITLE
Added Un-escaped Ampersands Checker for #107

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,3 +18,10 @@ jobs:
         with:
           config: './.markdownlint.yml'
           args: . 
+
+  journal-check:
+    name: Check Ampersands Un-escaped
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Python Ampersands Script
+        run: python3 check_ampersands.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
     # always run on pull requests
 jobs:
   markdown-check:
-    name: Check markdown
+    name: Check markdown and CSV formatting
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
@@ -18,10 +18,6 @@ jobs:
         with:
           config: './.markdownlint.yml'
           args: . 
-
-  journal-check:
-    name: Check Ampersands Un-escaped
-    runs-on: ubuntu-latest
-    steps:
       - name: Run Python Ampersands Script
         run: python3 check_ampersands.py
+      

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
     # always run on pull requests
 jobs:
   markdown-check:
-    name: Check markdown and CSV formatting
+    name: Check Markdown
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
@@ -18,6 +18,13 @@ jobs:
         with:
           config: './.markdownlint.yml'
           args: . 
+
+  ampersands-check:
+    name: Check Ampersands are Unescaped
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
       - name: Run Python Ampersands Script
         run: python3 check_ampersands.py
       

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,22 +3,23 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 2022-10
+## [Unreleased]
 
 ### Added
 
-- Added Escaped Ampersands Checker
-- check_ampersands.py which checks all csv journals in the journals folder to make
+- Added checker "Escaped Ampersands": `check_ampersands.py` which checks all csv journals in the journals folder to make
 sure all instances of ampersands are unescaped
 
 ### Changed
 
-- `.github/workflows/tests.yml` added the above script to the GitHub workflow so the check runs every time the main branch is pushed to
+- `.github/workflows/tests.yml` contains the script `check_ampersands.py`
 - Minor format changes in `README.md` and `LISENSE.md` as the old GitHub actions check was already failing
 - Found an escaped ampersands using the new script in `journal_abbreviations_dainst.csv` so this was ammended
-
 
 ## 2021-09
 
 Initial tagged release
+
 <!-- markdownlint-disable-file MD012 MD024 MD033 -->
+
+[Unreleased]: https://github.com/JabRef/abbrv.jabref.org/compare/2021-09...main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Initial tagged release
 
 ## 2022-10
+
 Added Escaped Ampersands Checker
+
 ### Added
+
 - check_ampersands.py which checks all csv journals in the journals folder to make
 sure all instances of ampersands are unescaped
+
 ### Changed 
+
 - `.github/workflows/tests.yml` added the above script to the GitHub workflow so the check runs every time the main branch is pushed to
 - Minor format changes in `README.md` and `LISENSE.md` as the old GitHub actions check was already failing
 - Found an escaped ampersands using the new script in `journal_abbreviations_dainst.csv` so this was ammended 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Initial tagged release
 
+## 2022-10
+Added Escaped Ampersands Checker
+### Added
+- check_ampersands.py which checks all csv journals in the journals folder to make
+sure all instances of ampersands are unescaped
+### Changed 
+- `.github/workflows/tests.yml` added the above script to the GitHub workflow so the check runs every time the main branch is pushed to
+- Minor format changes in `README.md` and `LISENSE.md` as the old GitHub actions check was already failing
+- Found an escaped ampersands using the new script in `journal_abbreviations_dainst.csv` so this was ammended 
+
 <!-- markdownlint-disable-file MD012 MD024 MD033 -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,11 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [UNRELEASED]
-
 ## 2022-10
-
-Added Escaped Ampersands Checker
 
 ### Added
 
+- Added Escaped Ampersands Checker
 - check_ampersands.py which checks all csv journals in the journals folder to make
 sure all instances of ampersands are unescaped
 
@@ -24,6 +21,4 @@ sure all instances of ampersands are unescaped
 ## 2021-09
 
 Initial tagged release
-
-
 <!-- markdownlint-disable-file MD012 MD024 MD033 -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,10 @@ Added Escaped Ampersands Checker
 - check_ampersands.py which checks all csv journals in the journals folder to make
 sure all instances of ampersands are unescaped
 
-### Changed 
+### Changed
 
 - `.github/workflows/tests.yml` added the above script to the GitHub workflow so the check runs every time the main branch is pushed to
 - Minor format changes in `README.md` and `LISENSE.md` as the old GitHub actions check was already failing
-- Found an escaped ampersands using the new script in `journal_abbreviations_dainst.csv` so this was ammended 
+- Found an escaped ampersands using the new script in `journal_abbreviations_dainst.csv` so this was ammended
 
 <!-- markdownlint-disable-file MD012 MD024 MD033 -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [UNRELEASED]
+
 ## 2022-10
 
 Added Escaped Ampersands Checker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,6 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 2021-09
-
-Initial tagged release
-
 ## 2022-10
 
 Added Escaped Ampersands Checker
@@ -21,5 +17,11 @@ sure all instances of ampersands are unescaped
 - `.github/workflows/tests.yml` added the above script to the GitHub workflow so the check runs every time the main branch is pushed to
 - Minor format changes in `README.md` and `LISENSE.md` as the old GitHub actions check was already failing
 - Found an escaped ampersands using the new script in `journal_abbreviations_dainst.csv` so this was ammended
+
+
+## 2021-09
+
+Initial tagged release
+
 
 <!-- markdownlint-disable-file MD012 MD024 MD033 -->

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,7 +2,7 @@
 
 CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED HEREUNDER.
 
-### Statement of Purpose
+## Statement of Purpose
 
 The laws of most jurisdictions throughout the world automatically confer exclusive Copyright and Related Rights (defined below) upon the creator and subsequent owner(s) (each and all, an "owner") of an original work of authorship and/or a database (each, a "Work").
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,6 @@ In case of duplicate appearances in the journal lists, the last occuring abbrevi
 * Frontend: <https://marcinwrochna.github.io/abbrevIso/>
 * API: <https://tools.wmflabs.org/abbreviso/>
 
-It takes the official list of ISO4 abbreviations of single words, plus the general rules defined in the ISO4 specifications to deduce the abbreviation for any journal name you input. 
+It takes the official list of ISO4 abbreviations of single words, plus the general rules defined in the ISO4 specifications to deduce the abbreviation for any journal name you input.
 
 Could be an alternative or complementary (when missing in the lists) approach to abbreviate journal names. But of course, it does not handle unabbreviation, for which there is no alternative to lists. It can also be a way to check the consistency of existing lists and it might make sense to link to the frontend on the abbrv.jabref website, so that people who want to add abbreviations can check for the correct one.

--- a/check_ampersands.py
+++ b/check_ampersands.py
@@ -1,18 +1,50 @@
 #!/usr/bin/env python3
 
+"""
+Python script for checking if all Ampersands in .csv journal abbreviation files are
+unescaped. This convention is enforced to ensure that abbreviations of journal titles
+can be done without error.
+
+The script will raise a ValueError() in case escaped ampersands are found, and will
+also provide the row and column in which they were found (1 -indexed). The script does
+NOT automatically fix these errors. This should be done manually.
+
+The script will automatically run whenever there is a push to the main branch of the
+abbreviations repo (abbrv.jabref.org) using GitHub Actions.
+"""
+
 import os
 import itertools
 
-path = "./journals/"
+# Get all file names in journal folders
+PATH_TO_JOURNALS = "./journals/"
+fileNames = next(itertools.islice(os.walk(PATH_TO_JOURNALS), 0, None))[2]
 
-fileNames = next(itertools.islice(os.walk(path), 0, None))[2]
+# Store ALL locations of escaped ampersands so they can all be printed upon failure
+errFileNames = []
+errRows = []
+errCols = []
 
 for file in fileNames:
     if (file.endswith(".csv")):
-        with open(path + file, "r") as f:
-            if ('\&' in f.read()):
-                raise ValueError("Found an escaped Ampersand in: " + file)
+        # For each .csv file in the folder, open in read mode
+        with open(PATH_TO_JOURNALS + file, "r") as f:
+            for i, line in enumerate(f):
+                # For each line, if it has \&, store the fname, row and columns
+                if ('\&' in line):
+                    errFileNames.append(file)
+                    errRows.append(i + 1)
+                    errCols.append([index + 1 for index in range(len(line)) if line.startswith('\&', index)])
 
 
-
-
+# In the case where we do find escaped &, the len() will be non-zero
+if (len(errFileNames) > 0):
+    err_msg = "["
+    # For each file, append every row:col location to the error message
+    for i, fname in enumerate(errFileNames):
+        for col in errCols[i]:
+            err_msg += "("+ fname + ", " + str(errRows[i]) + ":" + str(col) + "), "
+    # Format end of string and return as Value Error to 'fail' GitHub Actions process
+    err_msg = err_msg[:len(err_msg) - 2]
+    err_msg += "]"
+    raise ValueError("Found Escaped Ampersands at: " + err_msg)

--- a/check_ampersands.py
+++ b/check_ampersands.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+import os
+import itertools
+
+path = "./journals/"
+
+fileNames = next(itertools.islice(os.walk(path), 0, None))[2]
+
+for file in fileNames:
+    if (file.endswith(".csv")):
+        with open(path + file, "r") as f:
+            if ('\&' in f.read()):
+                raise ValueError("Found an escaped Ampersand in: " + file)
+
+
+
+

--- a/journals/journal_abbreviations_dainst.csv
+++ b/journals/journal_abbreviations_dainst.csv
@@ -55,7 +55,7 @@ Acta Universitatis Nicolai Copernici. Archaeologia;ActaTorunA
 Acta Universitatis Nicolai Copernici. Historia;ActaTorunHist
 Antike Denkmäler;AD
 Abhandlungen des Deutschen Archäologischen Instituts, Abteilung Kairo;ADAIK
-Adalya. Annual of the Suna \& Inan Kiraç-Research Institute on Mediterranean Civilizations;Adalya
+Adalya. Annual of the Suna & Inan Kiraç-Research Institute on Mediterranean Civilizations;Adalya
 Αρχαιολογικόν Δελτίον (Μελέτες);ADelt A
 Αρχαιολογικόν Δελτίον (Χρονικά);Adelt B
 Arkeoloji dergisi. Ege Üniversitesi Edebiyat Fakültesi;ADerg

--- a/update_mathscinet.py
+++ b/update_mathscinet.py
@@ -19,3 +19,4 @@ df = df[df["Full Title"].str.lower() != df["Abbrev"].str.lower()]
 
 # Save the end file in the same path as the old one
 df.to_csv(file_out, sep=";", escapechar="\\", index=False, header=False)
+


### PR DESCRIPTION
I am currently working on [#8948](https://github.com/JabRef/jabref/issues/8948) in the main JabRef repository. As a part of that issue, we need to check that all Ampersands stored in each csv is un-escaped. This PR contains a simple Python Script which checks each CSV for this condition, throwing a value error if we find an escaped ampersand. The script is configured to run each time there is a push to the main branch using GitHub actions, and integrates well with the existing format/lint checkers. I am seeking some feedback on whether or not this integrates well with the existing workflow, as well as general code conventions and quality. There are also some minor formatting changes as the existing GitHub Actions job was failing.

Thanks in advance!