### PR TITLE
Consistently use Int. to abbreviate International

### DIFF
--- a/journals/journal_abbreviations_mathematics.csv
+++ b/journals/journal_abbreviations_mathematics.csv
@@ -296,7 +296,7 @@ Annals of Science;Ann. of Sci.
 Annals of the Academy of Romanian Scientists. Series on Mathematics and its Applications;Ann. Acad. Rom. Sci. Ser. Math. Appl.
 Annals of the Canadian Society for History and Philosophy of Mathematics/Societe Canadienne d'Histoire et de Philosophie des Mathematiques;Ann. Can. Soc. Hist. Philos. Math./Soc. Can. Hist. Philos. Math.
 Annals of the Institute of Statistical Mathematics;Ann. Inst. Statist. Math.
-Annals of the International Society of Dynamic Games;Ann. Internat. Soc. Dynam. Games
+Annals of the International Society of Dynamic Games;Ann. Int. Soc. Dynam. Games
 Annals of the Japan Association for Philosophy of Science;Ann. Japan Assoc. Philos. Sci.
 Annals of the Tiberiu Popoviciu Seminar of Functional Equations, Approximation and Convexity;Ann. Tiberiu Popoviciu Semin. Funct. Equ. Approx. Convexity
 Annals of the University of Bucharest. Mathematical Series;Ann. Univ. Buchar. Math. Ser.
@@ -1168,7 +1168,7 @@ Fuzzy Information and Engineering;Fuzzy Inf. Eng.
 Fuzzy Management Methods;Fuzzy Manag. Methods
 Fuzzy Optimization and Decision Making. A Journal of Modeling and Computation Under Uncertainty;Fuzzy Optim. Decis. Mak.
 Fuzzy Sets and Systems. An International Journal in Information Science and Engineering;Fuzzy Sets and Systems
-GAKUTO International Series. Mathematical Sciences and Applications;GAKUTO Internat. Ser. Math. Sci. Appl.
+GAKUTO International Series. Mathematical Sciences and Applications;GAKUTO Int. Ser. Math. Sci. Appl.
 GAMM-Mitteilungen;GAMM-Mitt.
 GEM. International Journal on Geomathematics;GEM Int. J. Geomath.
 Game Theory and Applications;Game Theory Appl.
@@ -1223,7 +1223,7 @@ Gulf Journal of Mathematics;Gulf J. Math.
 HBA Lecture Notes in Mathematics;HBA Lect. Notes Math.
 Hacettepe Journal of Mathematics and Statistics;Hacet. J. Math. Stat.
 Handbook of Graph Grammars and Computing by Graph Transformation;Handb. Graph Gramm. Comput. Graph Transform.
-Handbook of International Documentation and Information;Handbook Internat. Doc. Info.
+Handbook of International Documentation and Information;Handbook Int. Doc. Info.
 Handbook of Numerical Analysis;Handb. Numer. Anal.
 Handbook of Philosophical Logic;Handb. Philos. Log.
 Handbook of Statistics;Handbook of Statist.
@@ -1305,7 +1305,7 @@ IFIP Congress Series;IFIP Congress Ser.
 IFIP Transactions;IFIP Trans.
 IFIP Transactions C: Communication Systems;IFIP Trans. C Comm. Systems
 IFSR International Series in Systems Science and Systems Engineering;IFSR Int. Ser. Syst. Sci. Syst. Eng.
-IFSR International Series on Systems Science and Engineering;IFSR Internat. Ser. Systems Sci. Engrg.
+IFSR International Series on Systems Science and Engineering;IFSR Int. Ser. Systems Sci. Engrg.
 IIASA Proceedings Series;IIASA Proc. Ser.
 IISc Lecture Notes Series;IISc Lect. Notes Ser.
 IMA Journal of Applied Mathematics;IMA J. Appl. Math.
@@ -1384,25 +1384,25 @@ Interdisciplinary Studies in Economics and Management;Interdiscip. Stud. Econ. M
 Interdisciplinary Studies on the Nature of Mathematics;Interdiscip. Stud. Nat. Math.
 Interdisciplinary Systems Research;Interdiscip. Systems Res.
 Interfaces and Free Boundaries. Mathematical Analysis, Computation and Applications;Interfaces Free Bound.
-International Applied Mechanics;Internat. Appl. Mech.
+International Applied Mechanics;Int. Appl. Mech.
 International Association for Mathematical Geosciences. Studies in Mathematical Geosciences;Int. Assoc. Math. Geosci. Stud. Math. Geosci.
-International Economic Review;Internat. Econom. Rev.
+International Economic Review;Int. Econom. Rev.
 International Electronic Journal of Algebra;Int. Electron. J. Algebra
 International Electronic Journal of Geometry;Int. Electron. J. Geom.
 International Electronic Journal of Pure and Applied Mathematics;Int. Electron. J. Pure Appl. Math.
 International Game Theory Review;Int. Game Theory Rev.
-International Geophysics Series;Internat. Geophys. Ser.
+International Geophysics Series;Int. Geophys. Ser.
 International Handbooks on Information Systems;Int. Handb. Inf. Syst.
 International Journal for Computational Methods in Engineering Science and Mechanics;Int. J. Comput. Methods Eng. Sci. Mech.
 International Journal for Numerical Methods in Biomedical Engineering;Int. J. Numer. Methods Biomed. Eng.
-International Journal for Numerical Methods in Engineering;Internat. J. Numer. Methods Engrg.
-International Journal for Numerical Methods in Fluids;Internat. J. Numer. Methods Fluids
+International Journal for Numerical Methods in Engineering;Int. J. Numer. Methods Engrg.
+International Journal for Numerical Methods in Fluids;Int. J. Numer. Methods Fluids
 International Journal for Uncertainty Quantification;Int. J. Uncertain. Quantif.
 International Journal of Adaptive Control and Signal Processing;Int. J. Adapt. Control Signal Process.
-International Journal of Adaptive Control and Signal Processing;Internat. J. Adapt. Control Signal Process.
+International Journal of Adaptive Control and Signal Processing;Int. J. Adapt. Control Signal Process.
 International Journal of Advances in Applied Mathematics and Mechanics;Int. J. Adv. Appl. Math. Mech.
 International Journal of Advances in Engineering Sciences and Applied Mathematics;Int. J. Adv. Eng. Sci. Appl. Math.
-International Journal of Algebra and Computation;Internat. J. Algebra Comput.
+International Journal of Algebra and Computation;Int. J. Algebra Comput.
 International Journal of Analysis;Int. J. Anal.
 International Journal of Applied Cryptography. IJACT;Int. J. Appl. Cryptogr.
 International Journal of Applied Mathematical Analysis and Applications;Int. J. Appl. Math. Anal. Appl.
@@ -1410,29 +1410,29 @@ International Journal of Applied Mathematical Sciences;Int. J. Appl. Math. Sci.
 International Journal of Applied Mathematics and Computation;Int. J. Appl. Math. Comput.
 International Journal of Applied Mathematics and Computer Science;Int. J. Appl. Math. Comput. Sci.
 International Journal of Applied Nonlinear Science;Int. J. Appl. Nonlinear Sci.
-International Journal of Applied Science and Computations;Internat. J. Appl. Sci. Comput.
+International Journal of Applied Science and Computations;Int. J. Appl. Sci. Comput.
 International Journal of Applied and Computational Mathematics;Int. J. Appl. Comput. Math.
-International Journal of Approximate Reasoning;Internat. J. Approx. Reason.
-International Journal of Bifurcation and Chaos in Applied Sciences and Engineering;Internat. J. Bifur. Chaos Appl. Sci. Engrg.
+International Journal of Approximate Reasoning;Int. J. Approx. Reason.
+International Journal of Bifurcation and Chaos in Applied Sciences and Engineering;Int. J. Bifur. Chaos Appl. Sci. Engrg.
 International Journal of Biomathematics;Int. J. Biomath.
 International Journal of Computational Fluid Dynamics;Int. J. Comput. Fluid Dyn.
-International Journal of Computational Geometry & Applications;Internat. J. Comput. Geom. Appl.
+International Journal of Computational Geometry & Applications;Int. J. Comput. Geom. Appl.
 International Journal of Computational Methods;Int. J. Comput. Methods
 International Journal of Computer Mathematics;Int. J. Comput. Math.
 International Journal of Computer Mathematics. Computer Systems Theory;Int. J. Comput. Math. Comput. Syst. Theory
 International Journal of Computer Vision;Int. J. Comput. Vis.
 International Journal of Computing Science and Mathematics;Int. J. Comput. Sci. Math.
-International Journal of Control;Internat. J. Control
+International Journal of Control;Int. J. Control
 International Journal of Difference Equations;Int. J. Difference Equ.
 International Journal of Differential Equations;Int. J. Differ. Equ.
 International Journal of Dynamical Systems and Differential Equations;Int. J. Dyn. Syst. Differ. Equ.
 International Journal of Dynamics and Control;Int. J. Dyn. Control
 International Journal of Economic Theory;Int. J. Econ. Theory
-International Journal of Engineering Science;Internat. J. Engrg. Sci.
+International Journal of Engineering Science;Int. J. Engrg. Sci.
 International Journal of Financial Engineering;Int. J. Financ. Eng.
-International Journal of Foundations of Computer Science;Internat. J. Found. Comput. Sci.
+International Journal of Foundations of Computer Science;Int. J. Found. Comput. Sci.
 International Journal of Fuzzy Systems;Int. J. Fuzzy Syst.
-International Journal of Game Theory;Internat. J. Game Theory
+International Journal of Game Theory;Int. J. Game Theory
 International Journal of General Systems;Int. J. Gen. Syst.
 International Journal of Geometric Methods in Modern Physics;Int. J. Geom. Methods Mod. Phys.
 International Journal of Geometry;Int. J. Geom.
@@ -1441,18 +1441,18 @@ International Journal of Image and Graphics;Int. J. Image Graph.
 International Journal of Information & Systems Sciences;Int. J. Inf. Syst. Sci.
 International Journal of Information and Coding Theory. IJICOT;Int. J. Inf. Coding Theory
 International Journal of Maps in Mathematics;Int. J. Maps Math.
-International Journal of Mathematical Education in Science and Technology;Internat. J. Math. Ed. Sci. Tech.
-International Journal of Mathematics;Internat. J. Math.
+International Journal of Mathematical Education in Science and Technology;Int. J. Math. Ed. Sci. Tech.
+International Journal of Mathematics;Int. J. Math.
 International Journal of Mathematics and Analysis. New Series;Int. J. Math. Anal. (N.S.)
 International Journal of Mathematics and Computer Science;Int. J. Math. Comput. Sci.
 International Journal of Mathematics and Mathematical Sciences;Int. J. Math. Math. Sci.
 International Journal of Mathematics and Statistics;Int. J. Math. Stat.
 International Journal of Mathematics for Industry;Int. J. Math. Ind.
 International Journal of Mathematics in Operational Research;Int. J. Math. Oper. Res.
-International Journal of Modern Physics A. Particles and Fields. Gravitation. Cosmology;Internat. J. Modern Phys. A
-International Journal of Modern Physics B;Internat. J. Modern Phys. B
-International Journal of Modern Physics C. Computational Physics and Physical Computation;Internat. J. Modern Phys. C
-International Journal of Modern Physics. D. Gravitation, Astrophysics, Cosmology;Internat. J. Modern Phys. D
+International Journal of Modern Physics A. Particles and Fields. Gravitation. Cosmology;Int. J. Modern Phys. A
+International Journal of Modern Physics B;Int. J. Modern Phys. B
+International Journal of Modern Physics C. Computational Physics and Physical Computation;Int. J. Modern Phys. C
+International Journal of Modern Physics. D. Gravitation, Astrophysics, Cosmology;Int. J. Modern Phys. D
 International Journal of Modern Physics: Conference Series;Int. J. Modern Phys. Conf. Ser.
 International Journal of Multiphase Flow;Int. J. Multiph. Flow
 International Journal of Nonlinear Science;Int. J. Nonlinear Sci.
@@ -1460,39 +1460,39 @@ International Journal of Nonlinear Sciences and Numerical Simulation;Int. J. Non
 International Journal of Number Theory;Int. J. Number Theory
 International Journal of Numerical Analysis and Modeling;Int. J. Numer. Anal. Model.
 International Journal of Numerical Analysis and Modeling. Series B;Int. J. Numer. Anal. Model. Ser. B
-International Journal of Numerical Methods for Heat & Fluid Flow;Internat. J. Numer. Methods Heat Fluid Flow
+International Journal of Numerical Methods for Heat & Fluid Flow;Int. J. Numer. Methods Heat Fluid Flow
 International Journal of Operational Research;Int. J. Oper. Res.
 International Journal of Operational Research Nepal. IJORN;Int. J. Oper. Res. Nepal
 International Journal of Operations Research;Int. J. Oper. Res. (Taichung)
 International Journal of Optimization. Theory Methods and Applications;Int. J. Optim. Theory Methods Appl.
 International Journal of Pattern Recognition and Artificial Intelligence;Int. J. Pattern Recognit. Artif. Intell.
 International Journal of Quantum Information;Int. J. Quantum Inf.
-International Journal of Robust and Nonlinear Control;Internat. J. Robust Nonlinear Control
+International Journal of Robust and Nonlinear Control;Int. J. Robust Nonlinear Control
 International Journal of Stochastic Analysis;Int. J. Stoch. Anal.
 International Journal of Structural Stability and Dynamics;Int. J. Struct. Stab. Dyn.
-International Journal of Systems Science. Principles and Applications of Systems and Integration;Internat. J. Systems Sci.
-International Journal of Theoretical Physics;Internat. J. Theoret. Phys.
+International Journal of Systems Science. Principles and Applications of Systems and Integration;Int. J. Systems Sci.
+International Journal of Theoretical Physics;Int. J. Theoret. Phys.
 International Journal of Theoretical and Applied Finance;Int. J. Theor. Appl. Finance
-International Journal of Uncertainty, Fuzziness and Knowledge-Based Systems;Internat. J. Uncertain. Fuzziness Knowledge-Based Systems
+International Journal of Uncertainty, Fuzziness and Knowledge-Based Systems;Int. J. Uncertain. Fuzziness Knowledge-Based Systems
 International Journal of Wavelets, Multiresolution and Information Processing;Int. J. Wavelets Multiresolut. Inf. Process.
 International Journal on Finite Volumes;Int. J. Finite Vol.
 International Law and Economics;Int. Law Econ.
 International Mathematics Research Notices. IMRN;Int. Math. Res. Not. IMRN
-International Series in Operations Research & Management Science;Internat. Ser. Oper. Res. Management Sci.
-International Series in Pure and Applied Physics;Internat. Ser. Pure Appl. Phys.
+International Series in Operations Research & Management Science;Int. Ser. Oper. Res. Management Sci.
+International Series in Pure and Applied Physics;Int. Ser. Pure Appl. Phys.
 International Series in Quantitative Marketing;Int. Ser. Quant. Mark.
-International Series of Monographs on Physics;Internat. Ser. Monogr. Phys.
-International Series of Numerical Mathematics;Internat. Ser. Numer. Math.
+International Series of Monographs on Physics;Int. Ser. Monogr. Phys.
+International Series of Numerical Mathematics;Int. Ser. Numer. Math.
 International Series on Actuarial Science;Int. Ser. Actuar. Sci.
-International Series on Applied Systems Analysis;Internat. Ser. Appl. Systems Anal.
-International Series on Systems and Control;Internat. Ser. Systems Control
+International Series on Applied Systems Analysis;Int. Ser. Appl. Systems Anal.
+International Series on Systems and Control;Int. Ser. Systems Control
 International Statistical Review. Revue Internationale de Statistique;Int. Stat. Rev.
-International Studies in Economic Modelling;Internat. Stud. Econom. Model.
+International Studies in Economic Modelling;Int. Stud. Econom. Model.
 International Studies in the History of Mathematics and its Teaching;Int. Stud. Hist. Math. Teach.
 International Studies in the Philosophy of Science;Int. Stud. Philos. Sci.
 International Transactions in Operational Research;Int. Trans. Oper. Res.
-International Trends in Manufacturing Technology;Internat. Trends Manufacturing Tech.
-International Union of Crystallography Crystallographic Symposia;Internat. Union Cryst. Cryst. Sympos.
+International Trends in Manufacturing Technology;Int. Trends Manufacturing Tech.
+International Union of Crystallography Crystallographic Symposia;Int. Union Cryst. Cryst. Sympos.
 Internet Mathematics;Internet Math.
 Invariant Theory and Algebraic Transformation Groups;Invariant Theory Algebr. Transform. Groups
 Inventiones Mathematicae;Invent. Math.
@@ -2541,7 +2541,7 @@ Practitioner Series;Pract. Ser.
 Pratsi Institutu Matematiki Natsionalnoi Akademii Nauk Ukraini. Matematika ta ii Zastosuvannya;Pr. Inst. Mat. Nats. Akad. Nauk Ukr. Mat. Zastos.
 Premier Cycle des Etudes Medicales;Prem. Cycle Etud. Med.
 Prentice Hall Information and System Sciences Series;Prentice Hall Inform. System Sci. Ser.
-Prentice Hall International Series in Computer Systems Science and Engineering;Prentice Hall Internat. Ser. Comput. Systems Sci. Engrg.
+Prentice Hall International Series in Computer Systems Science and Engineering;Prentice Hall Int. Ser. Comput. Systems Sci. Engrg.
 Prentice Hall Series in Advanced Communications Technologies;Prentice Hall Ser. Adv. Commun. Technol.
 Prentice Hall Series in Computer Science;Prentice Hall Ser. Comput. Sci.
 Prentice Hall Series in Statistics;Prentice Hall Ser. Statist.
@@ -2593,7 +2593,7 @@ Proceedings of the Estonian Academy of Sciences;Proc. Est. Acad. Sci.
 Proceedings of the Indian National Science Academy;Proc. Indian Nat. Sci. Acad.
 Proceedings of the Institute of Mathematics of the National Academy of Sciences of Ukraine. Mathematics and its Applications;Proc. Inst. Math. Natl. Acad. Sci. Ukr. Math. Appl.
 Proceedings of the Institute of Statistical Mathematics;Proc. Inst. Statist. Math.
-Proceedings of the International Centre for Heat and Mass Transfer;Proc. Internat. Centre Heat Mass Transfer
+Proceedings of the International Centre for Heat and Mass Transfer;Proc. Int. Centre Heat Mass Transfer
 Proceedings of the International Geometry Center;Proc. Int. Geom. Cent.
 Proceedings of the Jangjeon Mathematical Society. Memoirs of the Jangjeon Mathematical Society;Proc. Jangjeon Math. Soc.
 Proceedings of the London Mathematical Society. Third Series;Proc. Lond. Math. Soc. (3)
@@ -2908,7 +2908,7 @@ Series in Contemporary Applied Mathematics CAM;Ser. Contemp. Appl. Math. CAM
 Series in Contemporary Mathematics;Ser. Contemp. Math.
 Series in Display Science and Technology;Ser. Disp. Sci. Tech.
 Series in Electrical and Computer Engineering;Ser. Electr. Comput. Eng.
-Series in International Business and Economics;Ser. Internat. Bus. Econom.
+Series in International Business and Economics;Ser. Int. Bus. Econom.
 Series in Machine Perception and Artificial Intelligence;Ser. Mach. Percept. Artif. Intell.
 Series in Modern Condensed Matter Physics;Ser. Modern Condensed Matter Phys.
 Series in Optics and Optoelectronics;Ser. Opt. Optoelectron.
@@ -3298,9 +3298,9 @@ The Frontiers Collection;Front. Coll.
 The Graduate Journal of Mathematics;Grad. J. Math.
 The IMA Volumes in Mathematics and its Applications;IMA Vol. Math. Appl.
 The Information Retrieval Series;Inf. Retr. Ser.
-The International Cryogenics Monograph Series;Internat. Cryogenics Monogr. Ser.
+The International Cryogenics Monograph Series;Int. Cryogenics Monogr. Ser.
 The International Journal of Biostatistics;Int. J. Biostat.
-The International Library of Critical Writings in Economics;Internat. Lib. Crit. Writ. Econ.
+The International Library of Critical Writings in Economics;Int. Lib. Crit. Writ. Econ.
 The Japanese Economic Review. The Journal of the Japanese Economic Association;Jpn. Econ. Rev.
 The Japanese Journal of Behaviormetrics;Jpn. J. Behaviormetrics
 The Journal of Analysis;J. Anal.
@@ -3309,7 +3309,7 @@ The Journal of Fourier Analysis and Applications;J. Fourier Anal. Appl.
 The Journal of Symbolic Logic;J. Symb. Log.
 The Journal of Symplectic Geometry;J. Symplectic Geom.
 The Journal of the Indian Mathematical Society. New Series;J. Indian Math. Soc. (N.S.)
-The Kluwer International Series in Engineering and Computer Science. Knowledge Representation, Learning and Expert Systems;Kluwer Internat. Ser. Engrg. Comput. Sci. Knowledge Represent., Learn. Expert Systems
+The Kluwer International Series in Engineering and Computer Science. Knowledge Representation, Learning and Expert Systems;Kluwer Int. Ser. Engrg. Comput. Sci. Knowledge Represent., Learn. Expert Systems
 The Kluwer International Series in Software Engineering;Kluwer Int. Ser. Softw. Eng.
 The Korean Journal of Mathematics;Korean J. Math.
 The MIT Press Series in Structural Mechanics;MIT Press Ser. Structural Mech.


### PR DESCRIPTION
Some journals have used `Int.` as an abbreviation for `International`, some others have used `Internat.`. The short version is the correct version.

When merging this PR, all journal ins `journal_abbreviations_mathematics.csv` will consistently abbreviate the word `International` with `Int.`.