### PR TITLE
Update Applied Catalysis B: Environment and Energy

### DIFF
--- a/journals/journal_abbreviations_acs.csv
+++ b/journals/journal_abbreviations_acs.csv
@@ -113,8 +113,6 @@
 "Antiviral Research","Antiviral Res."
 "Applied Biochemistry and Biotechnology","Appl. Biochem. Biotechnol."
 "Applied Biochemistry and Microbiology","Appl. Biochem. Microbiol."
-"Applied Catalysis, A: General","Appl. Catal., A"
-"Applied Catalysis, B: Environmental","Appl. Catal., B"
 "Applied Clay Science","Appl. Clay Sci."
 "Applied Geochemistry","Appl. Geochem."
 "Applied Microbiology and Biotechnology","Appl. Microbiol. Biotechnol."

--- a/journals/journal_abbreviations_mechanical.csv
+++ b/journals/journal_abbreviations_mechanical.csv
@@ -278,6 +278,7 @@
 "Applied Bionics and Biomechanics","Appl. Bionics Biomech."
 "Applied Catalysis A: General","Appl. Catal., A"
 "Applied Catalysis B: Environmental","Appl. Catal., B"
+"Applied Catalysis B: Environment and Energy","Appl. Catal., B"
 "Applied Clay Science","Appl. Clay Sci."
 "Applied Composite Materials","Appl. Compos. Mater."
 "Applied Energy","Appl. Energy"


### PR DESCRIPTION
_Applied Catalysis B: Environment and Energy_, journal homepage: https://www.sciencedirect.com/journal/applied-catalysis-b-environment-and-energy

The journal has changed its name from _Applied Catalysis B: Environmental_ to _Applied Catalysis B: Environment and Energy_.

To maintain compatibility (it is still possible to match the old journal name to the abbreviation), the original name is preserved.

The journal is owned by Elsevier, not the American Chemical Society, so it has been removed from the acs.