### PR TITLE
Auto-merge Dependabot PRs

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,4 +1,4 @@
-name: automerge
+name: Dependabot auto-merge
 on: pull_request
 
 permissions:
@@ -6,16 +6,17 @@ permissions:
   pull-requests: write
 
 jobs:
-  github-actions:
+  dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'koppor' }}
+    if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
         with:
-          show-progress: ''
-      - name: Merge PR
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge
         run: gh pr merge --auto --squash "$PR_URL"
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Replace the koppor-only auto-merge workflow with a Dependabot-scoped one.

- Triggers only for `dependabot[bot]` PRs.
- Uses `dependabot/fetch-metadata` + `gh pr merge --auto --squash`.
- Repo already has `allow_auto_merge: true`, `delete_branch_on_merge: true`, and branch protection requiring the Markdown + Ampersands checks (strict) — so merge only completes once tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)