### PR TITLE
Also auto-merge github-actions[bot] PRs

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,4 +1,4 @@
-name: Dependabot auto-merge
+name: Auto-merge bot PRs
 on: pull_request
 
 permissions:
@@ -6,12 +6,12 @@ permissions:
   pull-requests: write
 
 jobs:
-  dependabot:
+  automerge:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.actor == 'dependabot[bot]' || github.actor == 'github-actions[bot]' }}
     steps:
       - name: Fetch Dependabot metadata
-        id: metadata
+        if: ${{ github.actor == 'dependabot[bot]' }}
         uses: dependabot/fetch-metadata@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Follow-up to #218. Extends the auto-merge workflow to also cover
`github-actions[bot]` PRs (the refresh-journal-lists updates, e.g. #213),
not just Dependabot. `fetch-metadata` stays gated to Dependabot only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)